### PR TITLE
Long messages

### DIFF
--- a/sepbar.c
+++ b/sepbar.c
@@ -15,6 +15,7 @@ static void sepbar_redraw(owl_window *w, WINDOW *sepwin, void *user_data)
   const owl_view *v;
   int x, y, i;
   const char *foo, *appendtosepbar;
+  int cur_numlines, cur_totallines;
 
   ml=owl_global_get_msglist(&g);
   v=owl_global_get_current_view(&g);
@@ -49,14 +50,6 @@ static void sepbar_redraw(owl_window *w, WINDOW *sepwin, void *user_data)
   if (strcmp(foo, owl_global_get_view_home(&g)))
       wattron(sepwin, A_REVERSE);
 
-  if (owl_mainwin_is_curmsg_truncated(owl_global_get_mainwin(&g))) {
-    getyx(sepwin, y, x);
-    wmove(sepwin, y, x+2);
-    wattron(sepwin, A_BOLD);
-    waddstr(sepwin, " <truncated> ");
-    wattroff(sepwin, A_BOLD);
-  }
-
   i=owl_mainwin_get_last_msg(owl_global_get_mainwin(&g));
   if ((i != -1) &&
       (i < owl_view_get_size(v)-1)) {
@@ -86,6 +79,16 @@ static void sepbar_redraw(owl_window *w, WINDOW *sepwin, void *user_data)
       waddstr(sepwin, " A-AWAY ");
     }
     wattron(sepwin, A_REVERSE);
+    wattroff(sepwin, A_BOLD);
+  }
+
+  if (owl_mainwin_is_curmsg_truncated(owl_global_get_mainwin(&g))) {
+    getyx(sepwin, y, x);
+    wmove(sepwin, y, x+2);
+    wattron(sepwin, A_BOLD);
+    cur_numlines = owl_global_get_curmsg_vert_offset(&g) + 1;
+    cur_totallines = owl_message_get_numlines(owl_view_get_element(v, owl_global_get_curmsg(&g)));
+    wprintw(sepwin, " <truncated: %d/%d> ", cur_numlines, cur_totallines);
     wattroff(sepwin, A_BOLD);
   }
 


### PR DESCRIPTION
These commits have been sitting around for a while.  I've just rebased them, and, as per davidben's suggestion from November, changed the -- to a : .  The style is <truncated: $m/$n>.  There's another style of this ($n/$m -- <truncated>) in https://github.com/JasonGross/barnowl/commits/long-message2, but I like this style better.  In particular, if you scroll into a truncated message, and then switch to one-line mode, the other style gives you something like 11/1 (or 11/0; I can't remember), which is weird.

For reference, davidben's comments were:

> Finally got around to playing with this... The dashes look somewhat odd. Maybe a colon would be better? More of a nuisance is that when you scroll off a message to the point that it isn't truncated, the number disappears. Perhaps the logic should be scrolled or truncated? Although, that feels kinda odd. Though perhaps what's actually odd is this separation of scroll through a message and scroll through a line; maybe messages should just be continuous.
> 
> Right now we have this weird thing here, especially given the scrolled || truncated logic, if you've scrolled off a message to the point that it is no longer truncated at the bottom, it shouldn't matter whether or not the stuff at the top you've truncated happens to be long enough that the message doesn't fit in the screen. Nevertheless, you can only get into such a state if this is true.
