### PR TITLE
Revert argv quoting

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -98,20 +98,13 @@ char *owl_cmddict_execute(const owl_cmddict *cd, const owl_context *ctx, const c
 }
 
 char *owl_cmddict_execute_argv(const owl_cmddict *cd, const owl_context *ctx, const char *const *argv, int argc) {
-  GString *buf = g_string_new("");
-  int i;
-  char *retval;
+  char *buff;
+  char *retval = NULL;
 
-  /* We weren't given a command line, so fabricate a valid one. */
-  for(i = 0; i < argc; i++) {
-    if (i != 0)
-      g_string_append_c(buf, ' ');
-    owl_string_append_quoted_arg(buf, argv[i]);
-  }
+  buff = g_strjoinv(" ", (char**)argv);
+  retval = _owl_cmddict_execute(cd, ctx, argv, argc, buff);
+  g_free(buff);
 
-  retval = _owl_cmddict_execute(cd, ctx, argv, argc, buf->str);
-
-  g_string_free(buf, true);
   return retval;
 }
 

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -42,7 +42,8 @@ command(cmd, ...)
 		if (items == 1) {
 			rv = owl_function_command(cmd);
 		} else {
-			argv = g_new(const char *, items + 1);
+			/* Ensure this is NULL-terminated. */
+			argv = g_new0(const char *, items + 1);
 			argv[0] = cmd;
 			for(i = 1; i < items; i++) {
 				argv[i] = SvPV_nolen(ST(i));


### PR DESCRIPTION
Use g_strjoinv in owl_cmddict_execute_argv, don't quote correctly

This reverts commit e3c8332fa85642544dba1222912b77cf6e32ce8c and uses
g_strjoinv instead. The correctly quoted form caused the j keybinding in
BarnOwl::Jabber to break. Without it, the world isn't sane this way
either:

  :perl BarnOwl::bindkey(recv => 'C-f C-f' => command => 'recv:next')

But a solution to this will probably be far more complex and bear little
relation to this commit. In the meantime master really shouldn't have
this obnoxious of a regression on it.
