### PR TITLE
Use owl_function_makemsg to report no search matches

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -2958,7 +2958,7 @@ void owl_function_search_helper(int consider_current, int direction)
   curmsg=owl_global_get_curmsg(&g);
   
   if (viewsize==0) {
-    owl_function_error("No messages present");
+    owl_function_makemsg("No messages present");
     return;
   }
 
@@ -2972,7 +2972,7 @@ void owl_function_search_helper(int consider_current, int direction)
 
   /* bounds check */
   if (start>=viewsize || start<0) {
-    owl_function_error("No further matches found");
+    owl_function_makemsg("No further matches found");
     return;
   }
 
@@ -3005,7 +3005,7 @@ void owl_function_search_helper(int consider_current, int direction)
     owl_function_unmask_sigint(NULL);
   }
   owl_mainwin_redisplay(owl_global_get_mainwin(&g));
-  owl_function_error("No matches found");
+  owl_function_makemsg("No matches found");
 }
 
 /* strips formatting from ztext and returns the unformatted text. 

--- a/viewwin.c
+++ b/viewwin.c
@@ -149,7 +149,7 @@ char *owl_viewwin_command_search(owl_viewwin *v, int argc, const char *const *ar
   }
 
   if (!owl_viewwin_search(v, owl_global_get_search_re(&g), consider_current, direction))
-    owl_function_error("No more matches");
+    owl_function_makemsg("No more matches");
   return NULL;
 }
 
@@ -171,7 +171,7 @@ static void owl_viewwin_callback_search(owl_editwin *e)
   }
   if (!owl_viewwin_search(data->v, owl_global_get_search_re(&g),
                           consider_current, data->direction))
-    owl_function_error("No matches");
+    owl_function_makemsg("No matches");
 }
 
 char *owl_viewwin_command_start_search(owl_viewwin *v, int argc, const char *const *argv, const char *buff)


### PR DESCRIPTION
It's not really an error; certainly not something that should end up in
the error log.
