### PR TITLE
Various punt cleanups

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -2478,7 +2478,7 @@ void owl_command_punt_unpunt(int argc, const char *const * argv, const char *buf
         owl_filter_delete(f);
         return;
       } else {
-        owl_function_error("No such filter number: %d", i+1);
+        owl_function_makemsg("No such filter number: %d.", i+1);
       }
     }
     const char *filter[] = {"filter", argv[1]};

--- a/functions.c
+++ b/functions.c
@@ -2857,11 +2857,13 @@ void owl_function_punt(int argc, const char *const *argv, int direction)
     }
   }
 
-  owl_function_debugmsg("punting");
-  /* If we're punting, add the filter to the global punt list */
-  if (direction==0) {
+  if (direction == 0) {
+    owl_function_debugmsg("punting");
+    /* If we're punting, add the filter to the global punt list */
     owl_list_append_element(fl, f);
-  }
+  } else if (direction == 1) {
+    owl_function_makemsg("No matching punt filter");
+ }
 }
 
 void owl_function_show_keymaps(void)


### PR DESCRIPTION
Fix up the documentation a bit, and don't use skiptokens in this command; there's no point. We may as well use the pre-tokenized form and avoid complicating whatever we end up doing to kill skiptokens.
