### PR TITLE
check for existence of file in owl_function_addstartup before calling owl_util_file_deleteline

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -3253,8 +3253,9 @@ void owl_function_addstartup(const char *buff)
 
   filename=owl_global_get_startupfile(&g);
 
-  /* delete earlier copies */
-  owl_util_file_deleteline(filename, buff, 1);
+  /* delete earlier copies, if the file exists */
+  if (g_file_test(filename, G_FILE_TEST_EXISTS))
+    owl_util_file_deleteline(filename, buff, 1);
 
   file=fopen(filename, "a");
   if (!file) {


### PR DESCRIPTION
> When ~/.owl/startup doesn't exist, barnowl produces an undesired error when the "startup" command is used for the first time, even though the command succeeds and ~/.owl/startup is successfully created with the correct contents:
> 
> Cannot open /afs/athena.mit.edu/user/other/paco//.owl/startup (for reading): No such file or directory

owl_function_addstartup checks for file before calling owl_util_file_deleteline

This fixes trac #175: '"startup" command produces error when run for the
first time'.  The startup command deletes duplicate lines, and thus
errored when no file existed.  A check has been added to prevent this.
