### PR TITLE
Use G_GNUC_WARN_UNUSED_RESULT

### DIFF
--- a/aim.c
+++ b/aim.c
@@ -427,7 +427,7 @@ int owl_aim_chat_sendmsg(const char *chatroom, const char *msg)
 }
 
 /* caller must free the return */
-char *owl_aim_normalize_screenname(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_aim_normalize_screenname(const char *in)
 {
   char *out;
   int i, j, k;

--- a/cmd.c
+++ b/cmd.c
@@ -8,9 +8,10 @@
 /***************************** COMMAND DICT *******************************/
 /**************************************************************************/
 
-int owl_cmddict_setup(owl_cmddict *cd) {
+void owl_cmddict_setup(owl_cmddict *cd)
+{
   owl_cmddict_init(cd);
-  return owl_cmd_add_defaults(cd);
+  owl_cmd_add_defaults(cd);
 }
 
 void owl_cmddict_init(owl_cmddict *cd) {
@@ -18,14 +19,12 @@ void owl_cmddict_init(owl_cmddict *cd) {
 }
 
 /* for bulk initialization at startup */
-int owl_cmddict_add_from_list(owl_cmddict *cd, const owl_cmd *cmds) {
+void owl_cmddict_add_from_list(owl_cmddict *cd, const owl_cmd *cmds)
+{
   const owl_cmd *cur;
-  int ret = 0;
   for (cur = cmds; cur->name != NULL; cur++) {
-    ret = owl_cmddict_add_cmd(cd, cur);
-    if (ret < 0) break;
+    owl_cmddict_add_cmd(cd, cur);
   }
-  return ret;
 }
 
 void owl_cmddict_get_names(const owl_cmddict *d, owl_list *l) {
@@ -37,13 +36,12 @@ const owl_cmd *owl_cmddict_find(const owl_cmddict *d, const char *name) {
 }
 
 /* creates a new command alias */
-int owl_cmddict_add_alias(owl_cmddict *cd, const char *alias_from, const char *alias_to) {
+void owl_cmddict_add_alias(owl_cmddict *cd, const char *alias_from, const char *alias_to) {
   owl_cmd *cmd;
   cmd = g_new(owl_cmd, 1);
   owl_cmd_create_alias(cmd, alias_from, alias_to);
   owl_perlconfig_new_command(cmd->name);
   owl_dict_insert_element(cd, cmd->name, cmd, (void (*)(void *))owl_cmd_delete);
-  return(0);
 }
 
 int owl_cmddict_add_cmd(owl_cmddict *cd, const owl_cmd * cmd) {
@@ -56,7 +54,9 @@ int owl_cmddict_add_cmd(owl_cmddict *cd, const owl_cmd * cmd) {
   return owl_dict_insert_element(cd, newcmd->name, newcmd, (void (*)(void *))owl_cmd_delete);
 }
 
-char *_owl_cmddict_execute(const owl_cmddict *cd, const owl_context *ctx, const char *const *argv, int argc, const char *buff) {
+/* caller must free the return */
+G_GNUC_WARN_UNUSED_RESULT char *_owl_cmddict_execute(const owl_cmddict *cd, const owl_context *ctx, const char *const *argv, int argc, const char *buff)
+{
   char *retval = NULL;
   const owl_cmd *cmd;
 
@@ -71,7 +71,9 @@ char *_owl_cmddict_execute(const owl_cmddict *cd, const owl_context *ctx, const 
   return retval;
 }
 
-char *owl_cmddict_execute(const owl_cmddict *cd, const owl_context *ctx, const char *cmdbuff) {
+/* caller must free the return */
+G_GNUC_WARN_UNUSED_RESULT char *owl_cmddict_execute(const owl_cmddict *cd, const owl_context *ctx, const char *cmdbuff)
+{
   char **argv;
   int argc;
   char *retval = NULL;
@@ -93,7 +95,9 @@ char *owl_cmddict_execute(const owl_cmddict *cd, const owl_context *ctx, const c
   return retval;
 }
 
-char *owl_cmddict_execute_argv(const owl_cmddict *cd, const owl_context *ctx, const char *const *argv, int argc) {
+/* caller must free the return */
+G_GNUC_WARN_UNUSED_RESULT char *owl_cmddict_execute_argv(const owl_cmddict *cd, const owl_context *ctx, const char *const *argv, int argc)
+{
   char *buff;
   char *retval = NULL;
 
@@ -120,12 +124,11 @@ int owl_cmd_create_from_template(owl_cmd *cmd, const owl_cmd *templ) {
   return(0);
 }
 
-int owl_cmd_create_alias(owl_cmd *cmd, const char *name, const char *aliased_to) {
+void owl_cmd_create_alias(owl_cmd *cmd, const char *name, const char *aliased_to) {
   memset(cmd, 0, sizeof(owl_cmd));
   cmd->name = g_strdup(name);
   cmd->cmd_aliased_to = g_strdup(aliased_to);
   cmd->summary = g_strdup_printf("%s%s", OWL_CMD_ALIAS_SUMMARY_PREFIX, aliased_to);
-  return(0);
 }
 
 void owl_cmd_cleanup(owl_cmd *cmd)
@@ -149,7 +152,9 @@ int owl_cmd_is_context_valid(const owl_cmd *cmd, const owl_context *ctx) {
   else return 0;
 }
 
-char *owl_cmd_execute(const owl_cmd *cmd, const owl_cmddict *cd, const owl_context *ctx, int argc, const char *const *argv, const char *cmdbuff) {
+/* caller must free the result */
+G_GNUC_WARN_UNUSED_RESULT char *owl_cmd_execute(const owl_cmd *cmd, const owl_cmddict *cd, const owl_context *ctx, int argc, const char *const *argv, const char *cmdbuff)
+{
   static int alias_recurse_depth = 0;
   int ival=0;
   const char *cmdbuffargs;
@@ -222,7 +227,8 @@ const char *owl_cmd_get_summary(const owl_cmd *cmd) {
 }
 
 /* returns a summary line describing this keymap.  the caller must free. */
-char *owl_cmd_describe(const owl_cmd *cmd) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_cmd_describe(const owl_cmd *cmd)
+{
   if (!cmd || !cmd->name || !cmd->summary) return NULL;
   return g_strdup_printf("%-25s - %s", cmd->name, cmd->summary);
 }

--- a/commands.c
+++ b/commands.c
@@ -40,7 +40,7 @@
           NULL, NULL, NULL, NULL, NULL, NULL, ((void(*)(void*,int))fn), NULL }
 
 
-int owl_cmd_add_defaults(owl_cmddict *cd)
+void owl_cmd_add_defaults(owl_cmddict *cd)
 {
   owl_cmd commands_to_init[] = {
 
@@ -1040,11 +1040,10 @@ int owl_cmd_add_defaults(owl_cmddict *cd)
 
   };
 
-  int ret = owl_cmddict_add_from_list(cd, commands_to_init);
+  owl_cmddict_add_from_list(cd, commands_to_init);
   owl_cmd *cmd;
   for (cmd = commands_to_init; cmd->name != NULL; cmd++)
     owl_cmd_cleanup(cmd);
-  return ret;
 }
 
 void owl_command_info(void)
@@ -1374,7 +1373,7 @@ done:
   return NULL;
 }
 
-char *owl_command_smartfilter(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_smartfilter(int argc, const char *const *argv, const char *buff)
 {
   char *filtname = NULL;
 
@@ -1414,7 +1413,7 @@ void owl_command_redisplay(void)
   owl_function_full_redisplay();
 }
 
-char *owl_command_get_shift(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_get_shift(int argc, const char *const *argv, const char *buff)
 {
   if(argc != 1)
   {
@@ -1645,37 +1644,37 @@ char *owl_command_print(int argc, const char *const *argv, const char *buff)
 }
 
 
-char *owl_command_exec(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_exec(int argc, const char *const *argv, const char *buff)
 {
   return owl_function_exec(argc, argv, buff, OWL_OUTPUT_RETURN);
 }
 
-char *owl_command_pexec(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_pexec(int argc, const char *const *argv, const char *buff)
 {
   return owl_function_exec(argc, argv, buff, OWL_OUTPUT_POPUP);
 }
 
-char *owl_command_aexec(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_aexec(int argc, const char *const *argv, const char *buff)
 {
   return owl_function_exec(argc, argv, buff, OWL_OUTPUT_ADMINMSG);
 }
 
-char *owl_command_perl(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_perl(int argc, const char *const *argv, const char *buff)
 {
   return owl_function_perl(argc, argv, buff, OWL_OUTPUT_RETURN);
 }
 
-char *owl_command_pperl(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_pperl(int argc, const char *const *argv, const char *buff)
 {
   return owl_function_perl(argc, argv, buff, OWL_OUTPUT_POPUP);
 }
 
-char *owl_command_aperl(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_aperl(int argc, const char *const *argv, const char *buff)
 {
   return owl_function_perl(argc, argv, buff, OWL_OUTPUT_ADMINMSG);
 }
 
-char *owl_command_multi(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_multi(int argc, const char *const *argv, const char *buff)
 {
   char *lastrv = NULL, *newbuff;
   char **commands;
@@ -2597,7 +2596,7 @@ char *owl_command_aimlogout(int argc, const char *const *argv, const char *buff)
   return(NULL);
 }
 
-char *owl_command_getstyle(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_getstyle(int argc, const char *const *argv, const char *buff)
 {
   const char *stylename;
   if (argc != 1) {
@@ -2641,7 +2640,7 @@ char *owl_command_add_cmd_history(int argc, const char *const *argv, const char 
   return NULL;
 }
 
-char *owl_command_with_history(int argc, const char *const *argv, const char *buff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_command_with_history(int argc, const char *const *argv, const char *buff)
 {
   owl_history *hist;
   const char *ptr;

--- a/context.c
+++ b/context.c
@@ -5,7 +5,7 @@
 #define SET_MODE(ctx, new) ctx->mode = ((ctx->mode)&~OWL_CTX_MODE_BITS)|new
 
 /* TODO: dependency from owl_context -> owl_window is annoying. */
-owl_context *owl_context_new(int mode, void *data, const char *keymap, owl_window *cursor)
+G_GNUC_WARN_UNUSED_RESULT owl_context *owl_context_new(int mode, void *data, const char *keymap, owl_window *cursor)
 {
   owl_context *c;
   if (!(mode & OWL_CTX_MODE_BITS))

--- a/dict.c
+++ b/dict.c
@@ -106,7 +106,8 @@ int owl_dict_insert_element(owl_dict *d, const char *k, void *v, void (*delete_o
 
 /* Doesn't free the value of the element, but does
  * return it so the caller can free it. */
-void *owl_dict_remove_element(owl_dict *d, const char *k) {
+G_GNUC_WARN_UNUSED_RESULT void *owl_dict_remove_element(owl_dict *d, const char *k)
+{
   int i;
   int pos, found;
   void *v;

--- a/editcontext.c
+++ b/editcontext.c
@@ -7,7 +7,7 @@ bool owl_is_editcontext(const owl_context *ctx)
   return owl_context_matches(ctx, OWL_CTX_TYPWIN);
 }
 
-owl_context *owl_editcontext_new(int mode, owl_editwin *e, const char *keymap, void (*deactivate_cb)(owl_context*), void *cbdata)
+G_GNUC_WARN_UNUSED_RESULT owl_context *owl_editcontext_new(int mode, owl_editwin *e, const char *keymap, void (*deactivate_cb)(owl_context*), void *cbdata)
 {
   owl_context *ctx = owl_context_new(mode, owl_editwin_ref(e), keymap,
 				     owl_editwin_get_window(e));

--- a/editwin.c
+++ b/editwin.c
@@ -60,7 +60,7 @@ static gunichar owl_editwin_get_char_at_point(owl_editwin *e);
 static int owl_editwin_replace_internal(owl_editwin *e, int replace, const char *s);
 static const char *oe_copy_buf(owl_editwin *e, const char *buf, int len);
 static int oe_copy_region(owl_editwin *e);
-static char *oe_chunk(owl_editwin *e, int start, int end);
+static G_GNUC_WARN_UNUSED_RESULT char *oe_chunk(owl_editwin *e, int start, int end);
 static void oe_destroy_cbdata(owl_editwin *e);
 static void oe_dirty(owl_editwin *e);
 static void oe_window_resized(owl_window *w, owl_editwin *e);
@@ -69,7 +69,7 @@ static void oe_window_resized(owl_window *w, owl_editwin *e);
 
 #define WHITESPACE " \n\t"
 
-static owl_editwin *owl_editwin_allocate(void)
+static G_GNUC_WARN_UNUSED_RESULT owl_editwin *owl_editwin_allocate(void)
 {
   owl_editwin *e = g_new0(owl_editwin, 1);
   e->refcount = 1;
@@ -141,7 +141,7 @@ static void _owl_editwin_init(owl_editwin *e,
   e->echochar='\0';
 }
 
-owl_editwin *owl_editwin_new(owl_window *win, int winlines, int wincols, int style, owl_history *hist)
+G_GNUC_WARN_UNUSED_RESULT owl_editwin *owl_editwin_new(owl_window *win, int winlines, int wincols, int style, owl_history *hist)
 {
   owl_editwin *e = owl_editwin_allocate();
 
@@ -1368,7 +1368,7 @@ const char *owl_editwin_get_text(owl_editwin *e)
   return(e->buff+e->lock);
 }
 
-char *owl_editwin_get_region(owl_editwin *e)
+G_GNUC_WARN_UNUSED_RESULT char *owl_editwin_get_region(owl_editwin *e)
 {
   int start, end;
   start = e->index;
@@ -1387,7 +1387,7 @@ int owl_editwin_get_echochar(owl_editwin *e)
   return e->echochar;
 }
 
-static char *oe_chunk(owl_editwin *e, int start, int end)
+static G_GNUC_WARN_UNUSED_RESULT char *oe_chunk(owl_editwin *e, int start, int end)
 {
   char *p;
   

--- a/filter.c
+++ b/filter.c
@@ -199,7 +199,7 @@ int owl_filter_message_match(const owl_filter *f, const owl_message *m)
 }
 
 
-char* owl_filter_print(const owl_filter *f)
+char G_GNUC_WARN_UNUSED_RESULT *owl_filter_print(const owl_filter *f)
 {
   GString *out = g_string_new("");
 

--- a/fmtext.c
+++ b/fmtext.c
@@ -170,7 +170,7 @@ void owl_fmtext_append_spaces(owl_fmtext *f, int nspaces)
 /* Return a plain version of the fmtext.  Caller is responsible for
  * freeing the return
  */
-char *owl_fmtext_print_plain(const owl_fmtext *f)
+char G_GNUC_WARN_UNUSED_RESULT *owl_fmtext_print_plain(const owl_fmtext *f)
 {
   return owl_strip_format_chars(f->buff->str);
 }

--- a/functions.c
+++ b/functions.c
@@ -13,14 +13,14 @@
 #include "owl.h"
 #include "filterproc.h"
 
-char *owl_function_command(const char *cmdbuff)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_command(const char *cmdbuff)
 {
   owl_function_debugmsg("executing command: %s", cmdbuff);
   return owl_cmddict_execute(owl_global_get_cmddict(&g), 
 			     owl_global_get_context(&g), cmdbuff);
 }
 
-char *owl_function_command_argv(const char *const *argv, int argc)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_command_argv(const char *const *argv, int argc)
 {
   return owl_cmddict_execute_argv(owl_global_get_cmddict(&g),
                                   owl_global_get_context(&g),
@@ -124,7 +124,8 @@ void owl_function_show_timers(void) {
   owl_fmtext_cleanup(&fm);
 }
 
-char *owl_function_style_describe(const char *name) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_style_describe(const char *name)
+{
   const char *desc;
   char *s;
   const owl_style *style;
@@ -140,7 +141,7 @@ char *owl_function_style_describe(const char *name) {
   return s;
 }
 
-char *owl_function_cmd_describe(const char *name)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_cmd_describe(const char *name)
 {
   const owl_cmd *cmd = owl_cmddict_find(owl_global_get_cmddict(&g), name);
   if (cmd) return owl_cmd_describe(cmd);
@@ -278,7 +279,7 @@ void owl_function_add_outgoing_zephyrs(const owl_zwrite *z)
  * create the message).  Does not put it on the global queue.  Use
  * owl_global_messagequeue_addmsg() for that.
  */
-owl_message *owl_function_make_outgoing_aim(const char *body, const char *to)
+G_GNUC_WARN_UNUSED_RESULT owl_message *owl_function_make_outgoing_aim(const char *body, const char *to)
 {
   owl_message *m;
 
@@ -299,7 +300,7 @@ owl_message *owl_function_make_outgoing_aim(const char *body, const char *to)
  * Does not append it to the global queue, use
  * owl_global_messagequeue_addmsg() for that.
  */
-owl_message *owl_function_make_outgoing_loopback(const char *body)
+G_GNUC_WARN_UNUSED_RESULT owl_message *owl_function_make_outgoing_loopback(const char *body)
 {
   owl_message *m;
 
@@ -1928,7 +1929,7 @@ void owl_function_start_command(const char *line)
   owl_editwin_set_callback(tw, owl_callback_command);
 }
 
-owl_editwin *owl_function_start_question(const char *line)
+G_GNUC_WARN_UNUSED_RESULT owl_editwin *owl_function_start_question(const char *line)
 {
   owl_editwin *tw;
   owl_context *ctx;
@@ -1943,7 +1944,7 @@ owl_editwin *owl_function_start_question(const char *line)
   return tw;
 }
 
-owl_editwin *owl_function_start_password(const char *line)
+G_GNUC_WARN_UNUSED_RESULT owl_editwin *owl_function_start_password(const char *line)
 {
   owl_editwin *tw;
   owl_context *ctx;
@@ -1960,7 +1961,7 @@ owl_editwin *owl_function_start_password(const char *line)
   return tw;
 }
 
-char *owl_function_exec(int argc, const char *const *argv, const char *buff, int type)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_exec(int argc, const char *const *argv, const char *buff, int type)
 {
   /* if type == 1 display in a popup
    * if type == 2 display an admin messages
@@ -2003,7 +2004,7 @@ char *owl_function_exec(int argc, const char *const *argv, const char *buff, int
   return NULL;
 }
 
-char *owl_function_perl(int argc, const char *const *argv, const char *buff, int type)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_perl(int argc, const char *const *argv, const char *buff, int type)
 {
   /* if type == 1 display in a popup
    * if type == 2 display an admin messages
@@ -2173,7 +2174,7 @@ void owl_function_create_filter(int argc, const char *const *argv)
  *
  * Returns the name of the negated filter, which the caller must free.
  */
-char *owl_function_create_negative_filter(const char *filtername)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_create_negative_filter(const char *filtername)
 {
   char *newname;
   const owl_filter *tmpfilt;
@@ -2270,7 +2271,7 @@ void owl_function_show_zpunts(void)
  * name of the filter or null.  The caller must free this name.
  * If 'related' is nonzero, encompass unclasses and .d classes as well.
  */
-char *owl_function_classinstfilt(const char *c, const char *i, int related) 
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_classinstfilt(const char *c, const char *i, int related) 
 {
   owl_filter *f;
   char *filtname;
@@ -2357,7 +2358,7 @@ done:
  * the configuration to override this function.  Returns the name of
  * the filter, which the caller must free.
  */
-char *owl_function_zuserfilt(const char *longuser)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_zuserfilt(const char *longuser)
 {
   owl_filter *f;
   char *argbuff, *esclonguser, *shortuser, *filtname;
@@ -2403,7 +2404,7 @@ char *owl_function_zuserfilt(const char *longuser)
  * created.  This allows the configuration to override this function.
  * Returns the name of the filter, which the caller must free.
  */
-char *owl_function_aimuserfilt(const char *user)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_aimuserfilt(const char *user)
 {
   owl_filter *f;
   char *argbuff, *filtname;
@@ -2441,7 +2442,7 @@ char *owl_function_aimuserfilt(const char *user)
   return(filtname);
 }
 
-char *owl_function_typefilt(const char *type)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_typefilt(const char *type)
 {
   owl_filter *f;
   char *argbuff, *filtname, *esctype;
@@ -2497,7 +2498,8 @@ void owl_function_delete_curview_msgs(int flag)
   owl_mainwin_redisplay(owl_global_get_mainwin(&g));  
 }
 
-static char *owl_function_smartfilter_cc(const owl_message *m) {
+static G_GNUC_WARN_UNUSED_RESULT char *owl_function_smartfilter_cc(const owl_message *m)
+{
   const char *ccs;
   char *ccs_quoted;
   char *filtname;
@@ -2548,7 +2550,7 @@ static char *owl_function_smartfilter_cc(const owl_message *m) {
  * If the curmsg is a personal AIM message returna  filter
  *    name to the AIM conversation with that user 
  */
-char *owl_function_smartfilter(int type, int invert_related)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_smartfilter(int type, int invert_related)
 {
   const owl_view *v;
   const owl_message *m;
@@ -2887,7 +2889,7 @@ void owl_function_show_keymaps(void)
   owl_fmtext_cleanup(&fm);
 }
 
-char *owl_function_keymap_summary(const char *name)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_keymap_summary(const char *name)
 {
   const owl_keymap *km 
     = owl_keyhandler_get_keymap(owl_global_get_keyhandler(&g), name);
@@ -3001,7 +3003,7 @@ void owl_function_search_helper(int consider_current, int direction)
 
 /* strips formatting from ztext and returns the unformatted text. 
  * caller is responsible for freeing. */
-char *owl_function_ztext_stylestrip(const char *zt)
+G_GNUC_WARN_UNUSED_RESULT char *owl_function_ztext_stylestrip(const char *zt)
 {
   owl_fmtext fm;
   char *plaintext;

--- a/global.c
+++ b/global.c
@@ -174,7 +174,8 @@ void owl_global_push_context_obj(owl_global *g, owl_context *c)
 
 /* Pops the current context from the context stack and returns it. Caller is
  * responsible for freeing. */
-owl_context *owl_global_pop_context_no_delete(owl_global *g) {
+G_GNUC_WARN_UNUSED_RESULT owl_context *owl_global_pop_context_no_delete(owl_global *g)
+{
   owl_context *c;
   if (!g->context_stack)
     return NULL;
@@ -726,7 +727,7 @@ void owl_global_messagequeue_addmsg(owl_global *g, owl_message *m)
  * is empty.  The caller should free the message after using it, if
  * necessary.
  */
-owl_message *owl_global_messagequeue_popmsg(owl_global *g)
+owl_message G_GNUC_WARN_UNUSED_RESULT *owl_global_messagequeue_popmsg(owl_global *g)
 {
   owl_message *out;
 

--- a/keybinding.c
+++ b/keybinding.c
@@ -13,7 +13,7 @@
 static int owl_keybinding_make_keys(owl_keybinding *kb, const char *keyseq);
 
 /* sets up a new keybinding for a command */
-owl_keybinding *owl_keybinding_new(const char *keyseq, const char *command, void (*function_fn)(void), const char *desc)
+G_GNUC_WARN_UNUSED_RESULT owl_keybinding *owl_keybinding_new(const char *keyseq, const char *command, void (*function_fn)(void), const char *desc)
 {
   owl_keybinding *kb = g_new(owl_keybinding, 1);
 
@@ -84,7 +84,7 @@ void owl_keybinding_execute(const owl_keybinding *kb, int j)
   }
 }
 
-char *owl_keybinding_stack_tostring(int *j, int len)
+G_GNUC_WARN_UNUSED_RESULT char *owl_keybinding_stack_tostring(int *j, int len)
 {
   GString *string;
   int  i;
@@ -99,7 +99,7 @@ char *owl_keybinding_stack_tostring(int *j, int len)
   return g_string_free(string, false);
 }
 
-char *owl_keybinding_tostring(const owl_keybinding *kb)
+G_GNUC_WARN_UNUSED_RESULT char *owl_keybinding_tostring(const owl_keybinding *kb)
 {
   return owl_keybinding_stack_tostring(kb->keys, kb->len);
 }

--- a/keymap.c
+++ b/keymap.c
@@ -50,8 +50,8 @@ int owl_keymap_create_binding(owl_keymap *km, const char *keyseq, const char *co
       owl_keybinding_delete(curkb);
     }
   }
-  return owl_list_append_element(&km->bindings, kb);  
-
+  owl_list_append_element(&km->bindings, kb);
+  return 0;
 }
 
 /* removes the binding associated with the keymap */
@@ -79,7 +79,7 @@ int owl_keymap_remove_binding(owl_keymap *km, const char *keyseq)
 
 
 /* returns a summary line describing this keymap.  the caller must free. */
-char *owl_keymap_summary(const owl_keymap *km)
+G_GNUC_WARN_UNUSED_RESULT char *owl_keymap_summary(const owl_keymap *km)
 {
   if (!km || !km->name || !km->desc) return NULL;
   return g_strdup_printf("%-15s - %s", km->name, km->desc);

--- a/keypress.c
+++ b/keypress.c
@@ -128,7 +128,7 @@ static const struct _owl_keypress_specialmap {
 #define OWL_CTRL(key) ((key)&037)
 /* OWL_META is definied in owl.h */
 
-char *owl_keypress_tostring(int j, int esc)
+char G_GNUC_WARN_UNUSED_RESULT *owl_keypress_tostring(int j, int esc)
 {
   GString *kb;
   const struct _owl_keypress_specialmap *sm;

--- a/list.c
+++ b/list.c
@@ -52,14 +52,14 @@ int owl_list_insert_element(owl_list *l, int at, void *element)
   return(0);
 }
 
-int owl_list_append_element(owl_list *l, void *element)
+void owl_list_append_element(owl_list *l, void *element)
 {
-  return owl_list_insert_element(l, l->size, element);
+  owl_list_insert_element(l, l->size, element);
 }
 
-int owl_list_prepend_element(owl_list *l, void *element)
+void owl_list_prepend_element(owl_list *l, void *element)
 {
-  return owl_list_insert_element(l, 0, element);
+  owl_list_insert_element(l, 0, element);
 }
 
 int owl_list_remove_element(owl_list *l, int n)

--- a/logging.c
+++ b/logging.c
@@ -79,7 +79,8 @@ int owl_log_shouldlog_message(const owl_message *m) {
   return(1);
 }
 
-char *owl_log_zephyr(const owl_message *m) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_log_zephyr(const owl_message *m)
+{
     char *tmp = NULL;
     GString *buffer = NULL;
     buffer = g_string_new("");
@@ -102,7 +103,8 @@ char *owl_log_zephyr(const owl_message *m) {
     return g_string_free(buffer, FALSE);
 }
 
-char *owl_log_aim(const owl_message *m) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_log_aim(const owl_message *m)
+{
     GString *buffer = NULL;
     buffer = g_string_new("");
     g_string_append_printf(buffer, "From: <%s> To: <%s>\n", 
@@ -119,7 +121,8 @@ char *owl_log_aim(const owl_message *m) {
     return g_string_free(buffer, FALSE);
 }
 
-char *owl_log_jabber(const owl_message *m) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_log_jabber(const owl_message *m)
+{
     GString *buffer = NULL;
     buffer = g_string_new("");
     g_string_append_printf(buffer, "From: <%s> To: <%s>\n",
@@ -131,7 +134,8 @@ char *owl_log_jabber(const owl_message *m) {
     return g_string_free(buffer, FALSE);
 }
 
-char *owl_log_generic(const owl_message *m) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_log_generic(const owl_message *m)
+{
     GString *buffer;
     buffer = g_string_new("");
     g_string_append_printf(buffer, "From: <%s> To: <%s>\n", 

--- a/message.c
+++ b/message.c
@@ -579,7 +579,7 @@ int owl_message_is_mail(const owl_message *m)
 }
 
 /* caller must free return value. */
-char *owl_message_get_cc(const owl_message *m)
+G_GNUC_WARN_UNUSED_RESULT char *owl_message_get_cc(const owl_message *m)
 {
   const char *cur;
   char *out, *end;
@@ -596,7 +596,7 @@ char *owl_message_get_cc(const owl_message *m)
 }
 
 /* caller must free return value */
-GList *owl_message_get_cc_without_recipient(const owl_message *m)
+G_GNUC_WARN_UNUSED_RESULT GList *owl_message_get_cc_without_recipient(const owl_message *m)
 {
   char *cc, *shortuser, *recip;
   const char *user;

--- a/messagelist.c
+++ b/messagelist.c
@@ -41,9 +41,9 @@ owl_message *owl_messagelist_get_by_id(const owl_messagelist *ml, int target_id)
   return(NULL);
 }
 
-int owl_messagelist_append_element(owl_messagelist *ml, void *element)
+void owl_messagelist_append_element(owl_messagelist *ml, void *element)
 {
-  return(owl_list_append_element(&(ml->list), element));
+  owl_list_append_element(&ml->list, element);
 }
 
 /* do we really still want this? */

--- a/owl.h
+++ b/owl.h
@@ -254,7 +254,7 @@ typedef struct _owl_variable {
 				/* returns a reference to the current value.
 				 * WARNING:  this approach is hard to make
 				 * thread-safe... */
-  char *(*get_tostring_fn)(const struct _owl_variable *v, const void *val);
+  char G_GNUC_WARN_UNUSED_RESULT *(*get_tostring_fn)(const struct _owl_variable *v, const void *val);
                                 /* converts val to a string;
 				 * caller must free the result */
   void (*delete_fn)(struct _owl_variable *v);
@@ -316,14 +316,14 @@ typedef struct _owl_cmd {	/* command */
   char *cmd_aliased_to;		/* what this command is aliased to... */
   
   /* These don't take any context */
-  char *(*cmd_args_fn)(int argc, const char *const *argv, const char *buff);  
+  char G_GNUC_WARN_UNUSED_RESULT *(*cmd_args_fn)(int argc, const char *const *argv, const char *buff);
 				/* takes argv and the full command as buff.
 				 * caller must free return value if !NULL */
   void (*cmd_v_fn)(void);	/* takes no args */
   void (*cmd_i_fn)(int i);	/* takes an int as an arg */
 
   /* The following also take the active context if it's valid */
-  char *(*cmd_ctxargs_fn)(void *ctx, int argc, const char *const *argv, const char *buff);  
+  char G_GNUC_WARN_UNUSED_RESULT *(*cmd_ctxargs_fn)(void *ctx, int argc, const char *const *argv, const char *buff);
 				/* takes argv and the full command as buff.
 				 * caller must free return value if !NULL */
   void (*cmd_ctxv_fn)(void *ctx);	        /* takes no args */

--- a/perlconfig.c
+++ b/perlconfig.c
@@ -22,7 +22,7 @@ void owl_perl_xs_init(pTHX) /* noproto */
 }
 
 
-SV *owl_new_sv(const char * str)
+G_GNUC_WARN_UNUSED_RESULT SV *owl_new_sv(const char * str)
 {
   SV *ret = newSVpv(str, 0);
   if (is_utf8_string((const U8 *)str, strlen(str))) {
@@ -35,7 +35,7 @@ SV *owl_new_sv(const char * str)
   return ret;
 }
 
-AV *owl_new_av(const owl_list *l, SV *(*to_sv)(const void *))
+G_GNUC_WARN_UNUSED_RESULT AV *owl_new_av(const owl_list *l, SV *(*to_sv)(const void *))
 {
   AV *ret;
   int i;
@@ -51,7 +51,7 @@ AV *owl_new_av(const owl_list *l, SV *(*to_sv)(const void *))
   return ret;
 }
 
-HV *owl_new_hv(const owl_dict *d, SV *(*to_sv)(const void *))
+G_GNUC_WARN_UNUSED_RESULT HV *owl_new_hv(const owl_dict *d, SV *(*to_sv)(const void *))
 {
   HV *ret;
   owl_list l;
@@ -74,7 +74,7 @@ HV *owl_new_hv(const owl_dict *d, SV *(*to_sv)(const void *))
   return ret;
 }
 
-SV *owl_perlconfig_message2hashref(const owl_message *m)
+G_GNUC_WARN_UNUSED_RESULT SV *owl_perlconfig_message2hashref(const owl_message *m)
 {
   HV *h, *stash;
   SV *hr;
@@ -164,7 +164,7 @@ SV *owl_perlconfig_message2hashref(const owl_message *m)
   return hr;
 }
 
-SV *owl_perlconfig_curmessage2hashref(void)
+G_GNUC_WARN_UNUSED_RESULT SV *owl_perlconfig_curmessage2hashref(void)
 {
   int curmsg;
   const owl_view *v;
@@ -182,7 +182,7 @@ SV *owl_perlconfig_curmessage2hashref(void)
 
    This has been somewhat addressed, but is still not lossless.
  */
-owl_message * owl_perlconfig_hashref2message(SV *msg)
+G_GNUC_WARN_UNUSED_RESULT owl_message *owl_perlconfig_hashref2message(SV *msg)
 {
   owl_message * m;
   HE * ent;
@@ -249,7 +249,7 @@ owl_message * owl_perlconfig_hashref2message(SV *msg)
 
 /* Calls in a scalar context, passing it a hash reference.
    If return value is non-null, caller must free. */
-char *owl_perlconfig_call_with_message(const char *subname, const owl_message *m)
+G_GNUC_WARN_UNUSED_RESULT char *owl_perlconfig_call_with_message(const char *subname, const owl_message *m)
 {
   dSP ;
   int count;
@@ -298,7 +298,7 @@ char *owl_perlconfig_call_with_message(const char *subname, const owl_message *m
 /* Calls a method on a perl object representing a message.
    If the return value is non-null, the caller must free it.
  */
-char * owl_perlconfig_message_call_method(const owl_message *m, const char *method, int argc, const char ** argv)
+G_GNUC_WARN_UNUSED_RESULT char *owl_perlconfig_message_call_method(const owl_message *m, const char *method, int argc, const char **argv)
 {
   dSP;
   unsigned int count, i;
@@ -347,8 +347,8 @@ char * owl_perlconfig_message_call_method(const owl_message *m, const char *meth
   return out;
 }
 
-
-char *owl_perlconfig_initperl(const char * file, int *Pargc, char ***Pargv, char *** Penv)
+/* caller must free result, if not NULL */
+G_GNUC_WARN_UNUSED_RESULT char *owl_perlconfig_initperl(const char *file, int *Pargc, char ***Pargv, char ***Penv)
 {
   int ret;
   PerlInterpreter *p;
@@ -434,7 +434,7 @@ int owl_perlconfig_is_function(const char *fn) {
 }
 
 /* caller is responsible for freeing returned string */
-char *owl_perlconfig_execute(const char *line)
+G_GNUC_WARN_UNUSED_RESULT char *owl_perlconfig_execute(const char *line)
 {
   STRLEN len;
   SV *response;
@@ -503,7 +503,8 @@ void owl_perlconfig_new_command(const char *name)
   LEAVE;
 }
 
-char *owl_perlconfig_perlcmd(const owl_cmd *cmd, int argc, const char *const *argv)
+/* caller must free the result */
+G_GNUC_WARN_UNUSED_RESULT char *owl_perlconfig_perlcmd(const owl_cmd *cmd, int argc, const char *const *argv)
 {
   int i, count;
   char * ret = NULL;

--- a/popwin.c
+++ b/popwin.c
@@ -1,6 +1,6 @@
 #include "owl.h"
 
-owl_popwin *owl_popwin_new(void)
+G_GNUC_WARN_UNUSED_RESULT owl_popwin *owl_popwin_new(void)
 {
   owl_popwin *pw = g_new0(owl_popwin, 1);
 

--- a/regex.c
+++ b/regex.c
@@ -38,11 +38,12 @@ int owl_regex_create(owl_regex *re, const char *string)
 int owl_regex_create_quoted(owl_regex *re, const char *string)
 {
   char *quoted;
+  int ret;
   
-  quoted=owl_text_quote(string, OWL_REGEX_QUOTECHARS, OWL_REGEX_QUOTEWITH);
-  owl_regex_create(re, quoted);
+  quoted = owl_text_quote(string, OWL_REGEX_QUOTECHARS, OWL_REGEX_QUOTEWITH);
+  ret = owl_regex_create(re, quoted);
   g_free(quoted);
-  return(0);
+  return ret;
 }
 
 int owl_regex_compare(const owl_regex *re, const char *string, int *start, int *end)

--- a/text.c
+++ b/text.c
@@ -6,7 +6,7 @@
 
 /* Returns a copy of 'in' with each line indented 'n'
  * characters. Result must be freed with g_free. */
-char *owl_text_indent(const char *in, int n)
+G_GNUC_WARN_UNUSED_RESULT char *owl_text_indent(const char *in, int n)
 {
   const char *ptr1, *ptr2, *last;
   GString *out = g_string_new("");
@@ -47,7 +47,7 @@ int owl_text_num_lines(const char *in)
 
 
 /* caller must free the return */
-char *owl_text_htmlstrip(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_text_htmlstrip(const char *in)
 {
   const char *ptr1, *end, *ptr2, *ptr3;
   char *out, *out2;
@@ -128,7 +128,7 @@ char *owl_text_htmlstrip(const char *in)
 }
 
 /* Caller must free return */
-char *owl_text_expand_tabs(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_text_expand_tabs(const char *in)
 {
   int len = 0;
   const char *p = in;
@@ -187,7 +187,7 @@ char *owl_text_expand_tabs(const char *in)
 }
 
 /* caller must free the return */
-char *owl_text_wordwrap(const char *in, int col)
+G_GNUC_WARN_UNUSED_RESULT char *owl_text_wordwrap(const char *in, int col)
 {
   char *out;
   int cur, lastspace, len, lastnewline;
@@ -268,7 +268,7 @@ int only_whitespace(const char *s)
 /* Return a string with any occurances of 'from' replaced with 'to'.
  * Caller must free returned string.
  */
-char *owl_text_substitute(const char *in, const char *from, const char *to)
+G_GNUC_WARN_UNUSED_RESULT char *owl_text_substitute(const char *in, const char *from, const char *to)
 {
   char **split = g_strsplit(in, from, 0), *out;
   out = g_strjoinv(to, split);
@@ -283,7 +283,7 @@ char *owl_text_substitute(const char *in, const char *from, const char *to)
  * permissable for a character in 'quotestr' to be in 'toquote'.
  * On success returns the string, on error returns NULL.
  */
-char *owl_text_quote(const char *in, const char *toquote, const char *quotestr)
+G_GNUC_WARN_UNUSED_RESULT char *owl_text_quote(const char *in, const char *toquote, const char *quotestr)
 {
   int i, x, r, place, escape;
   int in_len, toquote_len, quotestr_len;

--- a/util.c
+++ b/util.c
@@ -34,7 +34,7 @@ const char *skiptokens(const char *buff, int n) {
 /* Return a "nice" version of the path.  Tilde expansion is done, and
  * duplicate slashes are removed.  Caller must free the return.
  */
-char *owl_util_makepath(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_util_makepath(const char *in)
 {
   int i, j, x;
   char *out, user[MAXPATHLEN];
@@ -101,7 +101,7 @@ char *owl_util_makepath(const char *in)
    the returned values with g_strfreev.  If there is an error argc will be set
    to -1, argv will be NULL and the caller does not need to free anything. The
    returned vector is NULL-terminated. */
-char **owl_parseline(const char *line, int *argc)
+G_GNUC_WARN_UNUSED_RESULT char **owl_parseline(const char *line, int *argc)
 {
   GPtrArray *argv;
   int i, len, between=1;
@@ -244,7 +244,7 @@ void owl_string_vappendf_quoted(GString *buf, const char *tmpl, va_list ap)
   g_string_append(buf, last);
 }
 
-char *owl_string_build_quoted(const char *tmpl, ...)
+G_GNUC_WARN_UNUSED_RESULT char *owl_string_build_quoted(const char *tmpl, ...)
 {
   GString *buf = g_string_new("");
   va_list ap;
@@ -256,7 +256,7 @@ char *owl_string_build_quoted(const char *tmpl, ...)
 
 /* Returns a quoted version of arg suitable for placing in a
  * command-line. Result should be freed with g_free. */
-char *owl_arg_quote(const char *arg)
+G_GNUC_WARN_UNUSED_RESULT char *owl_arg_quote(const char *arg)
 {
   GString *buf = g_string_new("");;
   owl_string_append_quoted_arg(buf, arg);
@@ -264,7 +264,7 @@ char *owl_arg_quote(const char *arg)
 }
 
 /* caller must free the return */
-char *owl_util_minutes_to_timestr(int in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_util_minutes_to_timestr(int in)
 {
   int days, hours;
   long run;
@@ -330,7 +330,7 @@ const char *owl_util_color_to_string(int color)
 }
 
 /* Get the default tty name.  Caller must free the return */
-char *owl_util_get_default_tty(void)
+G_GNUC_WARN_UNUSED_RESULT char *owl_util_get_default_tty(void)
 {
   const char *tmp;
   char *out;
@@ -352,7 +352,7 @@ char *owl_util_get_default_tty(void)
 /* strip leading and trailing new lines.  Caller must free the
  * return.
  */
-char *owl_util_stripnewlines(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_util_stripnewlines(const char *in)
 {
   
   char  *tmp, *ptr1, *ptr2, *out;
@@ -383,7 +383,7 @@ char *owl_util_stripnewlines(const char *in)
  *
  * Error conditions are the same as g_file_read_link.
  */
-gchar *owl_util_recursive_resolve_link(const char *filename)
+G_GNUC_WARN_UNUSED_RESULT gchar *owl_util_recursive_resolve_link(const char *filename)
 {
   gchar *last_path = g_strdup(filename);
   GError *err = NULL;
@@ -510,7 +510,7 @@ int owl_util_file_deleteline(const char *filename, const char *line, int backup)
    leading `un' or trailing `.d'.
    The caller is responsible for freeing the allocated string.
 */
-char * owl_util_baseclass(const char * class)
+G_GNUC_WARN_UNUSED_RESULT char *owl_util_baseclass(const char *class)
 {
   char *start, *end;
 
@@ -545,8 +545,8 @@ const char * owl_get_bindir(void)
 }
 
 /* Strips format characters from a valid utf-8 string. Returns the
-   empty string if 'in' does not validate. */
-char * owl_strip_format_chars(const char *in)
+   empty string if 'in' does not validate.  Caller must free the return. */
+G_GNUC_WARN_UNUSED_RESULT char *owl_strip_format_chars(const char *in)
 {
   char *r;
   if (g_utf8_validate(in, -1, NULL)) {
@@ -583,8 +583,9 @@ char * owl_strip_format_chars(const char *in)
  * the caller to specify an alternative in the future. We also strip
  * out characters in Unicode Plane 16, as we use that plane internally
  * for formatting.
+ * Caller must free the return.
  */
-char * owl_validate_or_convert(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_validate_or_convert(const char *in)
 {
   if (g_utf8_validate(in, -1, NULL)) {
     return owl_strip_format_chars(in);
@@ -598,8 +599,9 @@ char * owl_validate_or_convert(const char *in)
 /*
  * Validate 'in' as UTF-8, and either return a copy of it, or an empty
  * string if it is invalid utf-8.
+ * Caller must free the return.
  */
-char * owl_validate_utf8(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_validate_utf8(const char *in)
 {
   char *out;
   if (g_utf8_validate(in, -1, NULL)) {
@@ -631,7 +633,8 @@ int owl_util_can_break_after(gunichar c)
   return 0;
 }
 
-char *owl_escape_highbit(const char *str)
+/* caller must free the return */
+G_GNUC_WARN_UNUSED_RESULT char *owl_escape_highbit(const char *str)
 {
   GString *out = g_string_new("");
   unsigned char c;
@@ -694,7 +697,7 @@ int owl_getline_chomp(char **s, FILE *fp)
 }
 
 /* Read the rest of the input available in fp into a string. */
-char *owl_slurp(FILE *fp)
+G_GNUC_WARN_UNUSED_RESULT char *owl_slurp(FILE *fp)
 {
   char *buf = NULL;
   char *p;

--- a/variable.c
+++ b/variable.c
@@ -646,7 +646,8 @@ void owl_variable_dict_add_variable(owl_vardict * vardict,
   owl_dict_insert_element(vardict, var->name, var, (void (*)(void *))owl_variable_delete);
 }
 
-owl_variable * owl_variable_newvar(const char *name, const char *summary, const char * description) {
+G_GNUC_WARN_UNUSED_RESULT owl_variable *owl_variable_newvar(const char *name, const char *summary, const char *description)
+{
   owl_variable * var = g_new0(owl_variable, 1);
   var->name = g_strdup(name);
   var->summary = g_strdup(summary);
@@ -824,7 +825,8 @@ int owl_variable_set_bool_off(owl_vardict *d, const char *name) {
   return owl_variable_set_int(d,name,0);
 }
 
-char *owl_variable_get_tostring(const owl_vardict *d, const char *name) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_variable_get_tostring(const owl_vardict *d, const char *name)
+{
   owl_variable *v;
   if (!name) return NULL;
   v = owl_dict_find_element(d, name);
@@ -832,7 +834,8 @@ char *owl_variable_get_tostring(const owl_vardict *d, const char *name) {
   return v->get_tostring_fn(v, v->get_fn(v));
 }
 
-char *owl_variable_get_default_tostring(const owl_vardict *d, const char *name) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_variable_get_default_tostring(const owl_vardict *d, const char *name)
+{
   owl_variable *v;
   if (!name) return NULL;
   v = owl_dict_find_element(d, name);
@@ -992,7 +995,8 @@ int owl_variable_bool_set_fromstring_default(owl_variable *v, const char *newval
   return (v->set_fn(v, &i));
 }
 
-char *owl_variable_bool_get_tostring_default(const owl_variable *v, const void *val) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_variable_bool_get_tostring_default(const owl_variable *v, const void *val)
+{
   if (val == NULL) {
     return g_strdup("<null>");
   } else if (*(const int*)val == 0) {
@@ -1027,7 +1031,8 @@ int owl_variable_int_set_fromstring_default(owl_variable *v, const char *newval)
   return (v->set_fn(v, &i));
 }
 
-char *owl_variable_int_get_tostring_default(const owl_variable *v, const void *val) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_variable_int_get_tostring_default(const owl_variable *v, const void *val)
+{
   if (val == NULL) {
     return g_strdup("<null>");
   } else {
@@ -1066,7 +1071,8 @@ int owl_variable_enum_set_fromstring(owl_variable *v, const char *newval) {
   return (v->set_fn(v, &val));
 }
 
-char *owl_variable_enum_get_tostring(const owl_variable *v, const void *val) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_variable_enum_get_tostring(const owl_variable *v, const void *val)
+{
   char **enums;
   int nenums, i;
   char *tostring;
@@ -1106,7 +1112,8 @@ int owl_variable_string_set_fromstring_default(owl_variable *v, const char *newv
   return (v->set_fn(v, newval));
 }
 
-char *owl_variable_string_get_tostring_default(const owl_variable *v, const void *val) {
+G_GNUC_WARN_UNUSED_RESULT char *owl_variable_string_get_tostring_default(const owl_variable *v, const void *val)
+{
   if (val == NULL) {
     return g_strdup("<null>");
   } else {

--- a/viewwin.c
+++ b/viewwin.c
@@ -11,7 +11,7 @@ static void owl_viewwin_set_window(owl_viewwin *v, owl_window *w);
 /* Create a viewwin.  'win' is an already initialized owl_window that
  * will be used by the viewwin
  */
-owl_viewwin *owl_viewwin_new_text(owl_window *win, const char *text)
+G_GNUC_WARN_UNUSED_RESULT owl_viewwin *owl_viewwin_new_text(owl_window *win, const char *text)
 {
   owl_viewwin *v = g_new0(owl_viewwin, 1);
   owl_fmtext_init_null(&(v->fmtext));
@@ -33,7 +33,7 @@ owl_viewwin *owl_viewwin_new_text(owl_window *win, const char *text)
 /* Create a viewwin.  'win' is an already initialized owl_window that
  * will be used by the viewwin
  */
-owl_viewwin *owl_viewwin_new_fmtext(owl_window *win, const owl_fmtext *fmtext)
+G_GNUC_WARN_UNUSED_RESULT owl_viewwin *owl_viewwin_new_fmtext(owl_window *win, const owl_fmtext *fmtext)
 {
   char *text;
   owl_viewwin *v = g_new0(owl_viewwin, 1);
@@ -236,7 +236,7 @@ void owl_viewwin_deactivate_editcontext(owl_context *ctx) {
   owl_viewwin_set_typwin_inactive(v);
 }
 
-owl_editwin *owl_viewwin_set_typwin_active(owl_viewwin *v, owl_history *hist) {
+G_GNUC_WARN_UNUSED_RESULT owl_editwin *owl_viewwin_set_typwin_active(owl_viewwin *v, owl_history *hist) {
   int lines, cols;
   owl_editwin *cmdline;
   if (v->cmdwin)

--- a/window.c
+++ b/window.c
@@ -568,7 +568,8 @@ static GSourceFuncs redraw_funcs = {
   NULL
 };
 
-GSource *owl_window_redraw_source_new(void) {
+G_GNUC_WARN_UNUSED_RESULT GSource *owl_window_redraw_source_new(void)
+{
   GSource *source;
   source = g_source_new(&redraw_funcs, sizeof(GSource));
   /* TODO: priority?? */

--- a/zcrypt.c
+++ b/zcrypt.c
@@ -52,10 +52,10 @@ typedef struct
   char *message;
 } ZWRITEOPTIONS;
 
-char *GetZephyrVarKeyFile(const char *whoami, const char *class, const char *instance);
+G_GNUC_WARN_UNUSED_RESULT char *GetZephyrVarKeyFile(const char *whoami, const char *class, const char *instance);
 int ParseCryptSpec(const char *spec, const char **keyfile);
-char *BuildArgString(char **argv, int start, int end);
-char *read_keystring(const char *keyfile);
+G_GNUC_WARN_UNUSED_RESULT char *BuildArgString(char **argv, int start, int end);
+G_GNUC_WARN_UNUSED_RESULT char *read_keystring(const char *keyfile);
 
 int do_encrypt(int zephyr, const char *class, const char *instance,
                ZWRITEOPTIONS *zoptions, const char* keyfile, int cipher);
@@ -363,7 +363,7 @@ int ParseCryptSpec(const char *spec, const char **keyfile) {
 
 /* Build a space-separated string from argv from elements between start  *
  * and end - 1.  malloc()'s the returned string. */
-char *BuildArgString(char **argv, int start, int end)
+G_GNUC_WARN_UNUSED_RESULT char *BuildArgString(char **argv, int start, int end)
 {
   int len = 1;
   int i;
@@ -400,7 +400,7 @@ char *BuildArgString(char **argv, int start, int end)
 #define MAX_BUFF 258
 #define MAX_SEARCH 3
 /* Find the class/instance in the .crypt-table */
-char *GetZephyrVarKeyFile(const char *whoami, const char *class, const char *instance)
+G_GNUC_WARN_UNUSED_RESULT char *GetZephyrVarKeyFile(const char *whoami, const char *class, const char *instance)
 {
   char *keyfile = NULL;
   char *varname[MAX_SEARCH];
@@ -578,7 +578,7 @@ void block_to_ascii(unsigned char *output, FILE *outfile)
   }
 }
 
-char *slurp_stdin(int ignoredot, int *length) {
+G_GNUC_WARN_UNUSED_RESULT char *slurp_stdin(int ignoredot, int *length) {
   char *buf;
   char *inptr;
 
@@ -610,7 +610,7 @@ char *slurp_stdin(int ignoredot, int *length) {
   return buf;
 }
 
-char *GetInputBuffer(ZWRITEOPTIONS *zoptions, int *length) {
+G_GNUC_WARN_UNUSED_RESULT char *GetInputBuffer(ZWRITEOPTIONS *zoptions, int *length) {
   char *buf;
 
   if (zoptions->flags & ZCRYPT_OPT_MESSAGE)
@@ -636,7 +636,7 @@ char *GetInputBuffer(ZWRITEOPTIONS *zoptions, int *length) {
   return buf;
 }
 
-char *read_keystring(const char *keyfile) {
+G_GNUC_WARN_UNUSED_RESULT char *read_keystring(const char *keyfile) {
   char *keystring;
   FILE *fkey = fopen(keyfile, "r");
   if(!fkey) {

--- a/zephyr.c
+++ b/zephyr.c
@@ -520,7 +520,7 @@ int owl_zephyr_unsub(const char *class, const char *inst, const char *recip)
  * definition).  Caller must free the return.
  */
 #ifdef HAVE_LIBZEPHYR
-char *owl_zephyr_get_field(const ZNotice_t *n, int j)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_get_field(const ZNotice_t *n, int j)
 {
   int i, count, save;
 
@@ -548,7 +548,7 @@ char *owl_zephyr_get_field(const ZNotice_t *n, int j)
   return(g_strdup(""));
 }
 
-char *owl_zephyr_get_field_as_utf8(const ZNotice_t *n, int j)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_get_field_as_utf8(const ZNotice_t *n, int j)
 {
   int i, count, save;
 
@@ -580,11 +580,11 @@ char *owl_zephyr_get_field_as_utf8(const ZNotice_t *n, int j)
   return(g_strdup(""));
 }
 #else
-char *owl_zephyr_get_field(void *n, int j)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_get_field(void *n, int j)
 {
   return(g_strdup(""));
 }
-char *owl_zephyr_get_field_as_utf8(void *n, int j)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_get_field_as_utf8(void *n, int j)
 {
   return owl_zephyr_get_field(n, j);
 }
@@ -617,7 +617,7 @@ int owl_zephyr_get_num_fields(const void *n)
 /* return a pointer to the message, place the message length in k
  * caller must free the return
  */
-char *owl_zephyr_get_message(const ZNotice_t *n, const owl_message *m)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_get_message(const ZNotice_t *n, const owl_message *m)
 {
 #define OWL_NFIELDS	5
   int i;
@@ -938,7 +938,7 @@ void owl_zephyr_hackaway_cr(ZNotice_t *n)
 }
 #endif
 
-char *owl_zephyr_zlocate(const char *user, int auth)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_zlocate(const char *user, int auth)
 {
 #ifdef HAVE_LIBZEPHYR
   int ret, numlocs;
@@ -1038,7 +1038,7 @@ void owl_zephyr_delsub(const char *filename, const char *class, const char *inst
 }
 
 /* caller must free the return */
-char *owl_zephyr_makesubline(const char *class, const char *inst, const char *recip)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_makesubline(const char *class, const char *inst, const char *recip)
 {
   return g_strdup_printf("%s,%s,%s\n", class, inst, !strcmp(recip, "") ? "*" : recip);
 }
@@ -1118,7 +1118,7 @@ const char *owl_zephyr_get_authstr(const void *n)
 /* Returns a buffer of subscriptions or an error message.  Caller must
  * free the return.
  */
-char *owl_zephyr_getsubs(void)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_getsubs(void)
 {
 #ifdef HAVE_LIBZEPHYR
   Code_t ret;
@@ -1238,7 +1238,7 @@ int owl_zephyr_set_exposure(const char *exposure)
 /* Strip a local realm fron the zephyr user name.
  * The caller must free the return
  */
-char *short_zuser(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *short_zuser(const char *in)
 {
   char *ptr = strrchr(in, '@');
   if (ptr && (ptr[1] == '\0' || !strcasecmp(ptr+1, owl_zephyr_get_realm()))) {
@@ -1250,7 +1250,7 @@ char *short_zuser(const char *in)
 /* Append a local realm to the zephyr user name if necessary.
  * The caller must free the return.
  */
-char *long_zuser(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *long_zuser(const char *in)
 {
   char *ptr = strrchr(in, '@');
   if (ptr) {
@@ -1278,7 +1278,7 @@ const char *zuser_realm(const char *in)
  * alone. Also leave rcmd. and daemon. krb4 principals alone. The
  * caller must free the return.
  */
-char *owl_zephyr_smartstripped_user(const char *in)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zephyr_smartstripped_user(const char *in)
 {
   char *slash, *dot, *realm, *out;
 

--- a/zwrite.c
+++ b/zwrite.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include "owl.h"
 
-owl_zwrite *owl_zwrite_new(const char *line)
+G_GNUC_WARN_UNUSED_RESULT owl_zwrite *owl_zwrite_new(const char *line)
 {
   owl_zwrite *z = g_new(owl_zwrite, 1);
   if (owl_zwrite_create_from_line(z, line) < 0) {
@@ -14,7 +14,7 @@ owl_zwrite *owl_zwrite_new(const char *line)
   return z;
 }
 
-int owl_zwrite_create_from_line(owl_zwrite *z, const char *line)
+G_GNUC_WARN_UNUSED_RESULT int owl_zwrite_create_from_line(owl_zwrite *z, const char *line)
 {
   int argc, badargs, myargc;
   char **argv;
@@ -320,7 +320,7 @@ const char *owl_zwrite_get_recip_n(const owl_zwrite *z, int n)
 }
 
 /* Caller must free the result. */
-char *owl_zwrite_get_recip_n_with_realm(const owl_zwrite *z, int n)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zwrite_get_recip_n_with_realm(const owl_zwrite *z, int n)
 {
   if (z->realm[0]) {
     return g_strdup_printf("%s@%s", owl_zwrite_get_recip_n(z, n), z->realm);
@@ -369,7 +369,7 @@ void owl_zwrite_cleanup(owl_zwrite *z)
  *
  * If not a CC, only the recip_index'th user will be replied to.
  */
-char *owl_zwrite_get_replyline(const owl_zwrite *z, int recip_index)
+G_GNUC_WARN_UNUSED_RESULT char *owl_zwrite_get_replyline(const owl_zwrite *z, int recip_index)
 {
   /* Match ordering in zwrite help. */
   GString *buf = g_string_new("");


### PR DESCRIPTION
Have gcc warn us when we ignore the result of a function that requires
the caller to free the result.  This might help (slightly) with
preventing leaks.
