### PR TITLE
AX_CHECK_FLAG: Fix to work with autoconf 2.59

### DIFF
--- a/m4/ax_check_flag.m4
+++ b/m4/ax_check_flag.m4
@@ -71,7 +71,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 2
+#serial 3
 
 AC_DEFUN([AX_CHECK_PREPROC_FLAG],
 [AC_PREREQ(2.59) dnl for _AC_LANG_PREFIX
@@ -80,10 +80,10 @@ AC_CACHE_CHECK([whether _AC_LANG preprocessor accepts $1], CACHEVAR, [
   ax_check_save_flags=$CPPFLAGS
   CPPFLAGS="$CPPFLAGS $4 $1"
   AC_PREPROC_IFELSE([AC_LANG_PROGRAM()],
-    [AS_VAR_SET([CACHEVAR],[yes])],
-    [AS_VAR_SET([CACHEVAR],[no])])
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
   CPPFLAGS=$ax_check_save_flags])
-AS_VAR_IF([CACHEVAR], "yes",
+AS_IF([test x"AS_VAR_GET(CACHEVAR)" = xyes],
   [m4_default([$2], :)],
   [m4_default([$3], :)])
 AS_VAR_POPDEF([CACHEVAR])dnl
@@ -96,10 +96,10 @@ AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
   _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
-    [AS_VAR_SET([CACHEVAR],[yes])],
-    [AS_VAR_SET([CACHEVAR],[no])])
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
   _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
-AS_VAR_IF([CACHEVAR], "yes",
+AS_IF([test x"AS_VAR_GET(CACHEVAR)" = xyes],
   [m4_default([$2], :)],
   [m4_default([$3], :)])
 AS_VAR_POPDEF([CACHEVAR])dnl
@@ -111,10 +111,10 @@ AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
   ax_check_save_flags=$LDFLAGS
   LDFLAGS="$LDFLAGS $4 $1"
   AC_LINK_IFELSE([AC_LANG_PROGRAM()],
-    [AS_VAR_SET([CACHEVAR],[yes])],
-    [AS_VAR_SET([CACHEVAR],[no])])
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
   LDFLAGS=$ax_check_save_flags])
-AS_VAR_IF([CACHEVAR], "yes",
+AS_IF([test x"AS_VAR_GET(CACHEVAR)" = xyes],
   [m4_default([$2], :)],
   [m4_default([$3], :)])
 AS_VAR_POPDEF([CACHEVAR])dnl
@@ -123,14 +123,18 @@ AS_VAR_POPDEF([CACHEVAR])dnl
 
 AC_DEFUN([AX_APPEND_FLAG],
 [AC_PREREQ(2.59) dnl for _AC_LANG_PREFIX
-AC_REQUIRE([AC_PROG_GREP])
-AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[]FLAGS)])dnl
-AS_VAR_SET_IF([FLAGS],
-  [AS_IF([AS_ECHO(" $[]FLAGS ") | $GREP " $1 " 2>&1 >/dev/null],
-    [AC_RUN_LOG([: FLAGS already contains $1])],
-    [AC_RUN_LOG([: FLAGS="$FLAGS $1"])
-    AS_VAR_APPEND([FLAGS], [" $1"])])],
-  [AS_VAR_SET([FLAGS],[$1])])
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])dnl
+AS_VAR_SET_IF(FLAGS,
+  [case " AS_VAR_GET(FLAGS) " in
+    *" $1 "*)
+      AC_RUN_LOG([: FLAGS already contains $1])
+      ;;
+    *)
+      AC_RUN_LOG([: FLAGS="$FLAGS $1"])
+      AS_VAR_SET(FLAGS, ["AS_VAR_GET(FLAGS) $1"])
+      ;;
+   esac],
+  [AS_VAR_SET(FLAGS,["$1"])])
 AS_VAR_POPDEF([FLAGS])dnl
 ])dnl AX_APPEND_FLAG
 


### PR DESCRIPTION
• AS_VAR_PUSHDEF([FLAGS], [something containing FLAGS]) caused an
  infinite loop before v2.65~21.
• AS_VAR_APPEND was new in v2.63b~224.
• AS_VAR_IF was new in v2.63~27.
• AS_VAR_ECHO was new in AUTOCONF-2.61a~45, and AC_PROG_GREP in
  AUTOCONF-2.59c~744, but their use here is more idiomatically
  replaced with a case pattern anyway.
• Before AUTOCONF-2.60b~8, the variable name passed to AC_CACHE_CHECK,
  AS_VAR_GET, AS_VAR_SET, and AS_VAR_SET_IF must be left unquoted.

Submitted upstream to https://savannah.gnu.org/patch/index.php?7563 .

Signed-off-by: Anders Kaseorg andersk@mit.edu
