### PR TITLE
Don't segfault when you expunge all messages from the messagelist

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -2497,7 +2497,7 @@ void owl_command_punt_unpunt(int argc, const char *const * argv, const char *buf
     owl_function_show_zpunts();
   } else if(argc == 2) {
     /* Handle :unpunt <number> */
-    if(unpunt && (i=atoi(argv[1])) !=0) {
+    if (unpunt && (i = atoi(argv[1])) > 0) {
       i--;      /* Accept 1-based indexing */
       if (i < fl->len) {
         owl_filter_delete(g_ptr_array_remove_index(fl, i));

--- a/messagelist.c
+++ b/messagelist.c
@@ -21,6 +21,7 @@ int owl_messagelist_get_size(const owl_messagelist *ml)
 
 void *owl_messagelist_get_element(const owl_messagelist *ml, int n)
 {
+  if (n >= ml->list->len) return NULL;
   return ml->list->pdata[n];
 }
 


### PR DESCRIPTION
When we used owl_list, trying to get an element from an empty list would
return NULL.  When we moved to GPtrArray, we dropped this checking,
without dropping the assumption that, e.g.,
 owl_view_get_element(v, owl_global_get_curmsg(&g));
works everywhere.  This commit adds the logic back in to deal with this
case.

Additionally, don't segfault on things like :unpunt -1.
