### PR TITLE
Run the unit tests before installing the locker build

### DIFF
--- a/scripts/locker-build
+++ b/scripts/locker-build
@@ -118,6 +118,8 @@ $TAR -C "$TMPDIR" -xzf "$SRC_TGZ" || die "Unable to untar"
 
     $MAKE -j$CPUS all || die "make failed"
 
+    $MAKE check || die "Unit tests failed"
+
     if [ -n "$DRYRUN" ]; then
         echo "Build completed; Dropping to a shell..."
         $SHELL


### PR DESCRIPTION
What's the point of having them if we don't force ourselves to run them more?
