### PR TITLE
Include the ncursesw headers

### DIFF
--- a/owl.h
+++ b/owl.h
@@ -17,8 +17,8 @@
 
 #ifndef OWL_PERL
 #define NCURSES_ENABLE_STDBOOL_H 1
-#include <curses.h>
-#include <panel.h>
+#include <ncursesw/curses.h>
+#include <ncursesw/panel.h>
 #endif
 #include <sys/param.h>
 #include <EXTERN.h>

--- a/tester.c
+++ b/tester.c
@@ -12,7 +12,7 @@
 #include <sys/types.h>
 
 #undef instr
-#include <curses.h>
+#include <ncursesw/curses.h>
 
 owl_global g;
 


### PR DESCRIPTION
They're apparently supposed to be compatible with the standard ones, but
we get wchar_t versions of various functions and should be able to
eliminate libncurses5-dev from the build deps.
