### PR TITLE
Perl logging

### DIFF
--- a/logging.c
+++ b/logging.c
@@ -17,23 +17,6 @@ static GThread *logging_thread;
 static bool defer_logs; /* to be accessed only on the disk-writing thread */
 static GQueue *deferred_entry_queue;
 
-/* This is now the one function that should be called to log a
- * message.  It will do all the work necessary by calling the other
- * functions in this file as necessary.
- */
-void owl_log_message(const owl_message *m) {
-  owl_function_debugmsg("owl_log_message: entering");
-
-  if (m == NULL) {
-    owl_function_debugmsg("owl_log_message: passed null message");
-    return;
-  }
-
-  g_free(owl_perlconfig_call_with_message("BarnOwl::Logging::log", m));
-
-  owl_function_debugmsg("owl_log_message: leaving");
-}
-
 static void owl_log_error_main_thread(gpointer data)
 {
   owl_function_error("%s", (const char*)data);

--- a/logging.c
+++ b/logging.c
@@ -29,49 +29,9 @@ void owl_log_message(const owl_message *m) {
     return;
   }
 
-  /* should we be logging this message? */
-  if (!owl_log_shouldlog_message(m)) {
-    owl_function_debugmsg("owl_log_message: not logging message");
-    return;
-  }
-
-  owl_log_perl(m);
+  g_free(owl_perlconfig_call_with_message("BarnOwl::Logging::log", m));
 
   owl_function_debugmsg("owl_log_message: leaving");
-}
-
-/* Return 1 if we should log the given message, otherwise return 0 */
-int owl_log_shouldlog_message(const owl_message *m) {
-  const owl_filter *f;
-
-  /* If there's a logfilter and this message matches it, log */
-  f=owl_global_get_filter(&g, owl_global_get_logfilter(&g));
-  if (f && owl_filter_message_match(f, m)) return(1);
-
-  /* otherwise we do things based on the logging variables */
-
-  /* skip login/logout messages if appropriate */
-  if (!owl_global_is_loglogins(&g) && owl_message_is_loginout(m)) return(0);
-      
-  /* check direction */
-  if ((owl_global_get_loggingdirection(&g)==OWL_LOGGING_DIRECTION_IN) && owl_message_is_direction_out(m)) {
-    return(0);
-  }
-  if ((owl_global_get_loggingdirection(&g)==OWL_LOGGING_DIRECTION_OUT) && owl_message_is_direction_in(m)) {
-    return(0);
-  }
-
-  if (owl_message_is_type_zephyr(m)) {
-    if (owl_message_is_personal(m) && !owl_global_is_logging(&g)) return(0);
-    if (!owl_message_is_personal(m) && !owl_global_is_classlogging(&g)) return(0);
-  } else {
-    if (owl_message_is_private(m) || owl_message_is_loginout(m)) {
-      if (!owl_global_is_logging(&g)) return(0);
-    } else {
-      if (!owl_global_is_classlogging(&g)) return(0);
-    }
-  }
-  return(1);
 }
 
 static void owl_log_error_main_thread(gpointer data)
@@ -301,51 +261,13 @@ void owl_log_enqueue_message(const char *buffer, const char *filename)
 		       owl_log_entry_free, log_context);
 }
 
-void owl_log_append(const owl_message *m, const char *filename) {
-  char *buffer = owl_perlconfig_message_call_method(m, "log", 0, NULL);
-  owl_log_enqueue_message(buffer, filename);
-  g_free(buffer);
-}
-
 void owl_log_outgoing_zephyr_error(const owl_zwrite *zw, const char *text)
 {
-  owl_message *m;
-  /* create a present message so we can pass it to
-   * owl_log_shouldlog_message(void)
-   */
-  m = g_slice_new(owl_message);
+  owl_message *m = g_slice_new(owl_message);
   /* recip_index = 0 because there can only be one recipient anyway */
   owl_message_create_from_zwrite(m, zw, text, 0);
-  if (!owl_log_shouldlog_message(m)) {
-    owl_message_delete(m);
-    return;
-  }
-  char *buffer = owl_perlconfig_message_call_method(m, "log_outgoing_error", 0, NULL);
-  char *filenames_string = owl_perlconfig_call_with_message("BarnOwl::Logging::get_filenames_as_string", m);
-  char **filenames = g_strsplit(filenames_string, " ", 0);
-  char **filename_ptr;
-
-  for (filename_ptr = filenames; *filename_ptr != NULL; filename_ptr++) {
-    owl_log_enqueue_message(buffer, *filename_ptr);
-  }
-
-  g_free(filenames_string);
-  g_strfreev(filenames);
+  g_free(owl_perlconfig_call_with_message("BarnOwl::Logging::log_outgoing_error", m));
   owl_message_delete(m);
-}
-
-void owl_log_perl(const owl_message *m)
-{
-  char *filenames_string = owl_perlconfig_call_with_message("BarnOwl::Logging::get_filenames_as_string", m);
-  char **filenames = g_strsplit(filenames_string, "\n", 0);
-  char **filename_ptr;
-  g_free(filenames_string);
-
-  for (filename_ptr = filenames; *filename_ptr != NULL; filename_ptr++) {
-    owl_log_append(m, *filename_ptr);
-  }
-
-  g_strfreev(filenames);
 }
 
 static gpointer owl_log_thread_func(gpointer data)

--- a/message.c
+++ b/message.c
@@ -397,12 +397,6 @@ int owl_message_is_type_aim(const owl_message *m)
   return owl_message_is_type(m, "aim");
 }
 
-/* XXX TODO: deprecate this */
-int owl_message_is_type_jabber(const owl_message *m)
-{
-  return owl_message_is_type(m, "jabber");
-}
-
 int owl_message_is_type_loopback(const owl_message *m)
 {
   return owl_message_is_type(m, "loopback");

--- a/owl.c
+++ b/owl.c
@@ -229,8 +229,6 @@ static int owl_process_message(owl_message *m) {
 
   /* let perl know about it */
   owl_perlconfig_newmsg(m, NULL);
-  /* log the message if we need to */
-  owl_log_message(m);
   /* redraw the sepbar; TODO: don't violate layering */
   owl_global_sepbar_dirty(&g);
 

--- a/perl/Makefile.am
+++ b/perl/Makefile.am
@@ -13,6 +13,7 @@ nobase_dist_pkgdata_DATA = \
 	lib/BarnOwl/Help.pm \
 	lib/BarnOwl/Hook.pm \
 	lib/BarnOwl/Hooks.pm \
+	lib/BarnOwl/Logging.pm \
 	lib/BarnOwl/MainLoopCompatHook.pm \
 	lib/BarnOwl/Message.pm \
 	lib/BarnOwl/Message/AIM.pm \

--- a/perl/lib/BarnOwl.pm
+++ b/perl/lib/BarnOwl.pm
@@ -37,6 +37,7 @@ use AnyEvent;
 
 use BarnOwl::Hook;
 use BarnOwl::Hooks;
+use BarnOwl::Logging;
 use BarnOwl::Message;
 use BarnOwl::Style;
 use BarnOwl::Zephyr;

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -90,6 +90,16 @@ sub _register_variables {
                            . "logged."
         });
 
+    BarnOwl::new_variable_string('logbasepath',
+        {
+            default       => '~/zlog',
+            validsettings => '<path>',
+            summary       => 'path for logging non-zephyr messages',
+            description   => "Specifies a directory which must exist.\n"
+                           . "Each non-zephyr protocol gets its own subdirectory in\n"
+                           . "logbasepath, and messages get logged there."
+        });
+
     BarnOwl::new_variable_string('logpath',
         {
             default       => '~/zlog/people',
@@ -140,7 +150,7 @@ Returns a list of filenames in which to log the passed message.
 
 This method calls C<log_filenames> on C<MESSAGE> to determine the list
 of filenames to which C<MESSAGE> gets logged.  All filenames are
-relative to C<MESSAGE->log_base_path>.  If C<MESSAGE->log_to_all_file>
+relative to C<MESSAGE->log_path>.  If C<MESSAGE->log_to_all_file>
 returns true, then the filename C<"all"> is appended to the list of
 filenames.
 
@@ -152,7 +162,7 @@ sub get_filenames {
     my ($m) = @_;
     my @filenames = $m->log_filenames;
     push @filenames, 'all' if $m->log_to_all_file;
-    return map { sanitize_filename($m->log_base_path, $_) } @filenames;
+    return map { sanitize_filename($m->log_path, $_) } @filenames;
 }
 
 =head2 should_log_message MESSAGE

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -34,6 +34,50 @@ our %EXPORT_TAGS = (all => [@EXPORT_OK]);
 use File::Spec;
 
 $BarnOwl::Hooks::newMessage->add("BarnOwl::Logging::log");
+$BarnOwl::Hooks::startup->add("BarnOwl::Logging::_register_variables");
+
+sub _register_variables {
+    BarnOwl::new_variable_bool('logging',
+        {
+            default     => 0,
+            summary     => 'turn personal logging on or off',
+            description => "If this is set to on, personal messages are\n"
+                         . "logged in the directory specified\n"
+                         . "by the 'logpath' variable.  The filename in that\n"
+                         . "directory is derived from the sender of the message."
+        });
+
+    BarnOwl::new_variable_bool('classlogging',
+        {
+            default     => 0,
+            summary     => 'turn class logging on or off',
+            description => "If this is set to on, class messages are\n"
+                         . "logged in the directory specified by the\n"
+                         . "'classpath' variable.  The filename in that\n"
+                         . "directory is derived from the class to which\n"
+                         . "the message was sent."
+        });
+
+    BarnOwl::new_variable_string('logfilter',
+        {
+            default     => '',
+            summary     => 'name of a filter controlling which messages to log',
+            description => "If non empty, any messages matching the given filter will be logged.\n"
+                         . "This is a completely separate mechanism from the other logging\n"
+                         . "variables like logging, classlogging, loglogins, loggingdirection,\n"
+                         . "etc.  If you want this variable to control all logging, make sure\n"
+                         . "all other logging variables are in their default state."
+        });
+
+    BarnOwl::new_variable_bool('loglogins',
+        {
+            default     => 0,
+            summary     => 'enable logging of login notifications',
+            description => "When this is enabled, BarnOwl will log login and logout notifications\n"
+                         . "for AIM, zephyr, or other protocols.  If disabled BarnOwl will not print\n"
+                         . "login or logout notifications."
+        });
+}
 
 =head2 sanitize_filename BASE_PATH FILENAME
 

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -119,6 +119,20 @@ sub _register_variables {
             description   => "Specifies a directory which must exist.\n"
                            . "Files will be created in the directory for each class."
         });
+
+    BarnOwl::new_variable_bool('log-to-subdirectories',
+        {
+            default     => 0,
+            summary     => "log each protocol to its own subdirectory of logbasepath",
+            description => "When this is enabled, BarnOwl will log each protocol to its own\n"
+                         . "subdirectory of logbasepath.  When this is disabled, BarnOwl will\n"
+                         . "instead log all non-zephyr non-loopback messages to the logpath,\n"
+                         . "and prefix each filename with what would otherwise be the subdirectory\n"
+                         . "name.\n\n"
+                         . "If you enable this, be sure that the relevant directories exist;\n"
+                         . "BarnOwl will not create them for you."
+        });
+
 }
 
 =head2 sanitize_filename BASE_PATH FILENAME

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -77,6 +77,36 @@ sub _register_variables {
                          . "for AIM, zephyr, or other protocols.  If disabled BarnOwl will not print\n"
                          . "login or logout notifications."
         });
+
+    BarnOwl::new_variable_enum('loggingdirection',
+        {
+            default       => 'both',
+            validsettings => [qw(in out both)],
+            summary       => "specifies which kind of messages should be logged",
+            description   => "Can be one of 'both', 'in', or 'out'.  If 'in' is\n"
+                           . "selected, only incoming messages are logged, if 'out'\n"
+                           . "is selected only outgoing messages are logged.  If 'both'\n"
+                           . "is selected both incoming and outgoing messages are\n"
+                           . "logged."
+        });
+
+    BarnOwl::new_variable_string('logpath',
+        {
+            default       => '~/zlog/people',
+            validsettings => '<path>',
+            summary       => 'path for logging personal messages',
+            description   => "Specifies a directory which must exist.\n"
+                            . "Files will be created in the directory for each sender."
+        });
+
+    BarnOwl::new_variable_string('classlogpath',
+        {
+            default       => '~/zlog/class',
+            validsettings => '<path>',
+            summary       => 'path for logging class zephyrs',
+            description   => "Specifies a directory which must exist.\n"
+                           . "Files will be created in the directory for each class."
+        });
 }
 
 =head2 sanitize_filename BASE_PATH FILENAME

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -143,10 +143,10 @@ sub _register_variables {
 
 Sanitizes C<FILENAME> and concatenates it with C<BASE_PATH>.
 
-In any filename, C<"/"> and any control characters (characters which
-match C<[:cntrl:]> get replaced by underscores.  If the resulting
-filename is empty or equal to C<"."> or C<"..">, it is replaced with
-C<"weird">.
+In any filename, C<"/">, any control characters (characters which
+match C<[:cntrl:]>), and any initial C<"."> characters get replaced by
+underscores.  If the resulting filename is empty, it is replaced with
+C<"_EMPTY_">.
 
 =cut
 
@@ -154,9 +154,8 @@ sub sanitize_filename {
     my $base_path = BarnOwl::Internal::makepath(shift);
     my $filename = shift;
     $filename =~ s/[[:cntrl:]\/]/_/g;
-    if ($filename eq '' || $filename eq '.' || $filename eq '..') {
-        $filename = 'weird';
-    }
+    $filename =~ s/^\./_/g; # handle ., .., and hidden files
+    $filename = '_EMPTY_' if $filename eq '';
     # The original C code also removed characters less than '!' and
     # greater than or equal to '~', marked file names beginning with a
     # non-alphanumeric or non-ASCII character as 'weird', and rejected

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -1,0 +1,88 @@
+use strict;
+use warnings;
+
+package BarnOwl::Logging;
+
+=head1 BarnOwl::Logging
+
+=head1 DESCRIPTION
+
+C<BarnOwl::Logging> implements the internals of logging.  All customizations
+to logging should be done in the appropriate subclass of L<BarnOwl::Message>.
+
+=head2 USAGE
+
+Modules wishing to customize how messages are logged should override the
+relevant subroutines in the appropriate subclass of L<BarnOwl::Message>.
+
+=head2 EXPORTS
+
+None by default.
+
+=cut
+
+use Exporter;
+
+our @EXPORT_OK = qw();
+
+our %EXPORT_TAGS = (all => [@EXPORT_OK]);
+
+use File::Spec;
+
+=head2 sanitize_filename BASE_PATH FILENAME
+
+Sanitizes C<FILENAME> and concatenates it with C<BASE_PATH>.
+
+In any filename, C<"/"> and any control characters (characters which
+match C<[:cntrl:]> get replaced by underscores.  If the resulting
+filename is empty or equal to C<"."> or C<"..">, it is replaced with
+C<"weird">.
+
+=cut
+
+sub sanitize_filename {
+    my $base_path = BarnOwl::Internal::makepath(shift);
+    my $filename = shift;
+    $filename =~ s/[[:cntrl:]\/]/_/g;
+    if ($filename eq '' || $filename eq '.' || $filename eq '..') {
+        $filename = 'weird';
+    }
+    # The original C code also removed characters less than '!' and
+    # greater than or equal to '~', marked file names beginning with a
+    # non-alphanumeric or non-ASCII character as 'weird', and rejected
+    # filenames longer than 35 characters.
+    return File::Spec->catfile($base_path, $filename);
+}
+
+=head2 get_filenames MESSAGE
+
+Returns a list of filenames in which to log the passed message.
+
+This method calls C<log_filenames> on C<MESSAGE> to determine the list
+of filenames to which C<MESSAGE> gets logged.  All filenames are
+relative to C<MESSAGE->log_base_path>.  If C<MESSAGE->log_to_all_file>
+returns true, then the filename C<"all"> is appended to the list of
+filenames.
+
+Filenames are sanitized by C<sanitize_filename>.
+
+=cut
+
+sub get_filenames {
+    my ($m) = @_;
+    my @filenames = $m->log_filenames;
+    push @filenames, 'all' if $m->log_to_all_file;
+    return map { sanitize_filename($m->log_base_path, $_) } @filenames;
+}
+
+# For ease of use in C
+sub get_filenames_as_string {
+    my @rtn;
+    foreach my $filename (BarnOwl::Logging::get_filenames(@_)) {
+        $filename =~ s/\n/_/g;
+        push @rtn, $filename;
+    }
+    return join("\n", @rtn);
+}
+
+1;

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -87,7 +87,11 @@ sub _register_variables {
                            . "selected, only incoming messages are logged, if 'out'\n"
                            . "is selected only outgoing messages are logged.  If 'both'\n"
                            . "is selected both incoming and outgoing messages are\n"
-                           . "logged."
+                           . "logged.\n\n"
+                           . "Note that this variable applies to all messages. In\n"
+                           . "particular, if this variable is set to 'out', the\n"
+                           . "classlogging variable will have no effect, and no\n"
+                           . "class messages will be logged."
         });
 
     BarnOwl::new_variable_string('logbasepath',

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -66,7 +66,7 @@ sub _register_variables {
                          . "This is a completely separate mechanism from the other logging\n"
                          . "variables like logging, classlogging, loglogins, loggingdirection,\n"
                          . "etc.  If you want this variable to control all logging, make sure\n"
-                         . "all other logging variables are in their default state."
+                         . "all other logging variables are left off (the default)."
         });
 
     BarnOwl::new_variable_bool('loglogins',
@@ -74,7 +74,7 @@ sub _register_variables {
             default     => 0,
             summary     => 'enable logging of login notifications',
             description => "When this is enabled, BarnOwl will log login and logout notifications\n"
-                         . "for AIM, zephyr, or other protocols.  If disabled BarnOwl will not print\n"
+                         . "for AIM, zephyr, or other protocols.  If disabled BarnOwl will not log\n"
                          . "login or logout notifications."
         });
 
@@ -91,7 +91,8 @@ sub _register_variables {
                            . "Note that this variable applies to all messages. In\n"
                            . "particular, if this variable is set to 'out', the\n"
                            . "classlogging variable will have no effect, and no\n"
-                           . "class messages will be logged."
+                           . "class messages (which are always incoming) will be\n"
+                           . "logged."
         });
 
     BarnOwl::new_variable_string('logbasepath',

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -33,6 +33,8 @@ our %EXPORT_TAGS = (all => [@EXPORT_OK]);
 
 use File::Spec;
 
+$BarnOwl::Hooks::newMessage->add("BarnOwl::Logging::log");
+
 =head2 sanitize_filename BASE_PATH FILENAME
 
 Sanitizes C<FILENAME> and concatenates it with C<BASE_PATH>.
@@ -115,6 +117,7 @@ L<BarnOwl::Message::log_filenames>.
 
 sub log {
     my ($m) = @_;
+    return unless defined $m;
     return unless BarnOwl::Logging::should_log_message($m);
     my $log_text = $m->log;
     foreach my $filename (BarnOwl::Logging::get_filenames($m)) {

--- a/perl/lib/BarnOwl/Logging.pm
+++ b/perl/lib/BarnOwl/Logging.pm
@@ -97,7 +97,9 @@ sub _register_variables {
             summary       => 'path for logging non-zephyr messages',
             description   => "Specifies a directory which must exist.\n"
                            . "Each non-zephyr protocol gets its own subdirectory in\n"
-                           . "logbasepath, and messages get logged there."
+                           . "logbasepath, and messages get logged there.  Note that\n"
+                           . "if the directory logbasepath/\$protocol does not exist,\n"
+                           . "logging will fail for \$protocol."
         });
 
     BarnOwl::new_variable_string('logpath',

--- a/perl/lib/BarnOwl/Message.pm
+++ b/perl/lib/BarnOwl/Message.pm
@@ -161,6 +161,56 @@ sub log_body {
     }
 }
 
+=head2 log_filenames MESSAGE
+
+Returns a list of filenames to which this message should be logged.
+The filenames should be relative to the path returned by
+C<log_base_path>.  See L<BarnOwl::Logging::get_filenames> for the
+specification of valid filenames, and for what happens if this
+method returns an invalid filename.
+
+=cut
+
+sub log_filenames {
+    my ($m) = @_;
+    my $filename = lc($m->type);
+    $filename = "unknown" if !defined $filename || $filename eq '';
+    if ($m->is_incoming && $m->pretty_sender) {
+        $filename .= ":" . $m->pretty_sender;
+    } elsif ($m->is_outgoing && $m->pretty_recipient) {
+        $filename .= ":" . $m->pretty_recipient;
+    }
+    return ($filename);
+}
+
+=head2 log_to_all_file MESSAGE
+
+There is an C<all> file.  This method determines if C<MESSAGE>
+should get logged to it, in addition to any files returned by
+C<log_filenames>.
+
+It defaults to returning true if and only if C<MESSAGE> is outgoing.
+
+=cut
+
+sub log_to_all_file {
+    my ($m) = @_;
+    return $m->is_outgoing;
+}
+
+=head2 log_base_path MESSAGE
+
+Returns the base path for logging, the folder in which all messages
+of this class get logged.
+
+Defaults to the BarnOwl variable C<logpath>.
+
+=cut
+
+sub log_base_path {
+    return BarnOwl::getvar('logpath');
+}
+
 # Populate the annoying legacy global variables
 sub legacy_populate_global {
     my ($m) = @_;

--- a/perl/lib/BarnOwl/Message.pm
+++ b/perl/lib/BarnOwl/Message.pm
@@ -116,6 +116,51 @@ sub serialize {
     return $s;
 }
 
+=head2 log MESSAGE
+
+Returns the text that should be written to a file to log C<MESSAGE>.
+
+=cut
+
+sub log {
+    my ($m) = @_;
+    return $m->log_header . "\n\n" . $m->log_body . "\n\n";
+}
+
+=head2 log_header MESSAGE
+
+Returns the header of the message, for logging purposes.
+If you override L<BarnOwl::Message::log>, this method is not called.
+
+=cut
+
+sub log_header {
+    my ($m) = @_;
+    my $sender = $m->sender;
+    my $recipient = $m->recipient;
+    my $timestr = $m->time;
+    return "From: <$sender> To: <$recipient>\n"
+         . "Time: $timestr";
+}
+
+=head2 log_body MESSAGE
+
+Returns the body of the message, for logging purposes.
+If you override L<BarnOwl::Message::log>, this method is not called.
+
+=cut
+
+sub log_body {
+    my ($m) = @_;
+    if ($m->is_loginout) {
+        return uc($m->login)
+            . $m->login_type
+            . ($m->login_extra ? ' at ' . $m->login_extra : '');
+    } else {
+        return $m->body;
+    }
+}
+
 # Populate the annoying legacy global variables
 sub legacy_populate_global {
     my ($m) = @_;

--- a/perl/lib/BarnOwl/Message.pm
+++ b/perl/lib/BarnOwl/Message.pm
@@ -211,6 +211,21 @@ sub log_base_path {
     return BarnOwl::getvar('logpath');
 }
 
+=head2 log_outgoing_error MESSAGE
+
+Returns the string that should be logged if there is an error sending
+an outgoing message.
+
+=cut
+
+sub log_outgoing_error {
+    my ($m) = @_;
+    my $recipient = $m->pretty_recipient;
+    my $body = $m->body;
+    chomp $body;
+    return "ERROR (BarnOwl): $recipient\n$body\n\n";
+}
+
 # Populate the annoying legacy global variables
 sub legacy_populate_global {
     my ($m) = @_;

--- a/perl/lib/BarnOwl/Message.pm
+++ b/perl/lib/BarnOwl/Message.pm
@@ -226,6 +226,26 @@ sub log_outgoing_error {
     return "ERROR (BarnOwl): $recipient\n$body\n\n";
 }
 
+=head2 should_log MESSAGE
+
+Returns true if we should log C<MESSAGE>.  This does not override
+user settings; if the BarnOwl variable C<loggingdirection> is in,
+and C<MESSAGE> is outgoing and does not match the C<logfilter>, it
+will not get logged regardless of what this method returns.
+
+Note that this method I<does> override the BarnOwl C<logging>
+variable; if a derived class overrides this method and does not
+provide an alternative BarnOwl variable (such as C<classlogging>),
+the overriding method should check the BarnOwl C<logging> variable.
+
+Defaults to returning the value of the BarnOwl variable C<logging>.
+
+=cut
+
+sub should_log {
+    return BarnOwl::getvar('logging') eq 'on';
+}
+
 # Populate the annoying legacy global variables
 sub legacy_populate_global {
     my ($m) = @_;

--- a/perl/lib/BarnOwl/Message.pm
+++ b/perl/lib/BarnOwl/Message.pm
@@ -182,7 +182,11 @@ sub log_filenames {
         $filename = $m->pretty_recipient;
     }
     $filename = "unknown" if !defined($filename) || $filename eq '';
-    return ($filename);
+    if (BarnOwl::getvar('log-to-subdirectories') eq 'on') {
+        return ($filename);
+    } else {
+        return ($m->log_subfolder . ':' . $filename);
+    }
 }
 
 =head2 log_to_all_file MESSAGE
@@ -204,13 +208,22 @@ sub log_to_all_file {
 
 Returns the folder in which all messages of this class get logged.
 
-Defaults to C<log_base_path>/C<log_subfolder>.
+Defaults to C<log_base_path/log_subfolder> if C<log-to-subdirectories>
+is enabled, or to the C<logpath> BarnOwl variable if it is not.
+
+Most protocols should override C<log_subfolder> rather than
+C<log_path>, in order to properly take into account the value of
+C<log-to-subdirectories>.
 
 =cut
 
 sub log_path {
     my ($m) = @_;
-    return File::Spec->catfile($m->log_base_path, $m->log_subfolder);
+    if (BarnOwl::getvar('log-to-subdirectories') eq 'on') {
+        return File::Spec->catfile($m->log_base_path, $m->log_subfolder);
+    } else {
+        return BarnOwl::getvar('logpath');
+    }
 }
 
 =head2 log_base_path MESSAGE

--- a/perl/lib/BarnOwl/Message/AIM.pm
+++ b/perl/lib/BarnOwl/Message/AIM.pm
@@ -23,5 +23,14 @@ sub replysendercmd {
     return shift->replycmd;
 }
 
+sub normalize_screenname {
+    my ($screenname) = @_;
+    $screenname =~ s/\s+//g;
+    return lc($screenname);
+}
+
+sub log_filenames {
+    return map { normalize_screenname($_) } BarnOwl::Message::log_filenames(@_);
+}
 
 1;

--- a/perl/lib/BarnOwl/Message/Loopback.pm
+++ b/perl/lib/BarnOwl/Message/Loopback.pm
@@ -13,5 +13,7 @@ sub is_private {
 sub replycmd {return 'loopwrite';}
 sub replysendercmd {return 'loopwrite';}
 
+sub log_subfolder { return ''; }
+sub log_filenames { return ('loopback'); }
 
 1;

--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -263,7 +263,7 @@ sub log_filenames {
     } else {
         push @filenames, $m->recipient;
     }
-    return map { lc(NFKC(strip_realm($_))) } @filenames;
+    return map { lc(NFKC(BarnOwl::zephyr_smartstrip_user(strip_realm($_)))) } @filenames;
 }
 
 sub log_to_class_file {

--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -222,5 +222,21 @@ sub replysendercmd {
     return $self->replycmd(1);
 }
 
+# Logging
+sub log_header {
+    my ($m) = @_;
+    my $class = $m->class;
+    my $instance = $m->instance;
+    my $opcode = $m->opcode;
+    my $timestr = $m->time;
+    my $host = $m->host;
+    my $sender = $m->pretty_sender;
+    my $zsig = $m->zsig;
+    my $rtn = "Class: $class Instance: $instance";
+    $rtn .= " Opcode: $opcode" unless !defined $opcode || $opcode eq '';
+    $rtn .= "\nTime: $timestr Host: $host"
+          . "\nFrom: $zsig <$sender>";
+    return $rtn;
+}
 
 1;

--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -273,7 +273,7 @@ sub log_to_class_file {
     return !$m->is_personal;
 }
 
-sub log_base_path {
+sub log_path {
     my ($m) = @_;
     if ($m->log_to_class_file) {
         return BarnOwl::getvar('classlogpath');

--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -280,4 +280,13 @@ sub log_base_path {
     }
 }
 
+sub should_log {
+    my ($m) = @_;
+    if ($m->log_to_class_file) {
+        return BarnOwl::getvar('classlogging') eq 'on';
+    } else {
+        return BarnOwl::getvar('logging') eq 'on';
+    }
+}
+
 1;

--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -258,7 +258,9 @@ sub log_filenames {
         if ($m->is_personal) {
             push @filenames, $m->sender;
         } else {
-            return (lc(NFKC($m->class)));
+            my $realm = '';
+            $realm .= '@' . $m->realm if $m->realm ne BarnOwl::zephyr_getrealm();
+            return (lc(NFKC($m->class)) . $realm);
         }
     } else {
         push @filenames, $m->recipient;

--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -144,6 +144,8 @@ sub zephyr_cc {
     return undef;
 }
 
+# Note: This is the cc-line without the recipient; it does not include
+# the sender.
 sub zephyr_cc_without_recipient {
     my $self = shift;
     my $recipient = lc(strip_realm($self->recipient));

--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -27,7 +27,10 @@ sub casefold_principal {
     # split the principal right after the final @, without eating any
     # characters; this way, we always get at least '@' in $user
     my ($user, $realm) = split(/(?<=@)(?=[^@]+$)/, $principal);
-    return lc($user) . uc($realm);
+    $user = '' if !defined $user;
+    $user = lc($user);
+    $user = $user . uc($realm) if defined $realm;
+    return $user;
 }
 
 sub login_type {

--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -262,6 +262,7 @@ sub log_filenames {
     my ($m) = @_;
     my @filenames = ();
     if ($m->is_personal) {
+        # If this has CC's, add all but the "recipient" which we'll add below
         @filenames = $m->zephyr_cc_without_recipient;
     }
     if ($m->is_incoming) {

--- a/perl/modules/IRC/lib/BarnOwl/Message/IRC.pm
+++ b/perl/modules/IRC/lib/BarnOwl/Message/IRC.pm
@@ -96,7 +96,7 @@ sub log_filenames {
     my ($m) = @_;
     die "IRC should not be handling non-IRC messages" if lc($m->type) ne "irc";
     BarnOwl::error("IRC message without a network") if !defined($m->network) || $m->network eq '';
-    my $filename = lc($m->type) . ":" . lc($m->network);
+    my $filename = lc($m->network);
     if ($m->is_personal) {
         if ($m->is_incoming) {
             $filename .= ":" . $m->sender;

--- a/perl/modules/IRC/lib/BarnOwl/Message/IRC.pm
+++ b/perl/modules/IRC/lib/BarnOwl/Message/IRC.pm
@@ -91,4 +91,22 @@ sub login_extra {
     }
 }
 
+# logging
+sub log_filenames {
+    my ($m) = @_;
+    die "IRC should not be handling non-IRC messages" if lc($m->type) ne "irc";
+    BarnOwl::error("IRC message without a network") if !defined($m->network) || $m->network eq '';
+    my $filename = lc($m->type) . ":" . lc($m->network);
+    if ($m->is_personal) {
+        if ($m->is_incoming) {
+            $filename .= ":" . $m->sender;
+        } elsif ($m->is_outgoing) {
+            $filename .= ":" . $m->recipient;
+        }
+    } else {
+        $filename .= ":" . $m->channel;
+    }
+    return ($filename);
+}
+
 1;

--- a/perl/modules/IRC/lib/BarnOwl/Message/IRC.pm
+++ b/perl/modules/IRC/lib/BarnOwl/Message/IRC.pm
@@ -97,6 +97,10 @@ sub log_filenames {
     die "IRC should not be handling non-IRC messages" if lc($m->type) ne "irc";
     BarnOwl::error("IRC message without a network") if !defined($m->network) || $m->network eq '';
     my $filename = lc($m->network);
+    # Note: Channel names generally start with '#', which
+    # disambiguates channels from individuals; for example, personals
+    # will look like, e.g., "~/zlog/irc/freenode:john-doe", whereas
+    # channels will look like, e.g., "~/zlog/irc/freenode:#barnowl"
     if ($m->is_personal) {
         if ($m->is_incoming) {
             $filename .= ":" . $m->sender;

--- a/perl/modules/IRC/lib/BarnOwl/Message/IRC.pm
+++ b/perl/modules/IRC/lib/BarnOwl/Message/IRC.pm
@@ -109,4 +109,16 @@ sub log_filenames {
     return ($filename);
 }
 
+sub log {
+    my ($m) = @_;
+    my $sender = $m->sender;
+    my $timestr = $m->time;
+    my $body = $m->body;
+    if ($m->is_loginout) {
+        return BarnOwl::Message::log($m);
+    } else {
+        return "[$timestr] <$sender> $body\n";
+    }
+}
+
 1;

--- a/perl/modules/Jabber/lib/BarnOwl/Message/Jabber.pm
+++ b/perl/modules/Jabber/lib/BarnOwl/Message/Jabber.pm
@@ -14,7 +14,6 @@ A subclass of BarnOwl::Message for Jabber messages
 package BarnOwl::Message::Jabber;
 
 use base qw( BarnOwl::Message );
-use Unicode::Normalize qw( NFKC );
 
 sub jtype { shift->{jtype} };
 sub from { shift->{from} };
@@ -173,7 +172,7 @@ sub jwrite_cmd {
 }
 
 sub log_filenames {
-    return map { lc(NFKC($_)) } BarnOwl::Message::log_filenames(@_);
+    return map { BarnOwl::compat_casefold($_) } BarnOwl::Message::log_filenames(@_);
 }
 
 =head1 SEE ALSO

--- a/perl/modules/Jabber/lib/BarnOwl/Message/Jabber.pm
+++ b/perl/modules/Jabber/lib/BarnOwl/Message/Jabber.pm
@@ -14,6 +14,7 @@ A subclass of BarnOwl::Message for Jabber messages
 package BarnOwl::Message::Jabber;
 
 use base qw( BarnOwl::Message );
+use Unicode::Normalize qw( NFKC );
 
 sub jtype { shift->{jtype} };
 sub from { shift->{from} };
@@ -169,6 +170,10 @@ sub jwrite_cmd {
     } else {
         return undef;
     }
+}
+
+sub log_filenames {
+    return map { lc(NFKC($_)) } BarnOwl::Message::log_filenames(@_);
 }
 
 =head1 SEE ALSO

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -435,6 +435,19 @@ file_deleteline(filename, line, backup)
 	OUTPUT:
 		RETVAL
 
+const utf8 *
+makepath(in)
+	const char * in
+	PREINIT:
+		char *rv;
+	CODE:
+		rv = owl_util_makepath(in);
+		RETVAL = rv;
+	OUTPUT:
+		RETVAL
+	CLEANUP:
+		g_free(rv);
+
 void
 new_command(name, func, summary, usage, description)
 	char *name

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -412,6 +412,19 @@ get_variable_info(name)
 	OUTPUT:
 		RETVAL
 
+const utf8 *
+compat_casefold(in)
+	const char * in
+	PREINIT:
+		char *rv;
+	CODE:
+		rv = owl_util_compat_casefold(in);
+		RETVAL = rv;
+	OUTPUT:
+		RETVAL
+	CLEANUP:
+		g_free(rv);
+
 
 MODULE = BarnOwl		PACKAGE = BarnOwl::Zephyr
 

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -682,3 +682,12 @@ mark()
 		}
 	OUTPUT:
 		RETVAL
+
+MODULE = BarnOwl		PACKAGE = BarnOwl::Logging
+
+void
+enqueue_text(log_text, filename)
+	const char * log_text
+	const char * filename
+	CODE:
+		owl_log_enqueue_message(log_text, filename);

--- a/t/BarnOwl_Message_Zephyr.t
+++ b/t/BarnOwl_Message_Zephyr.t
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test::More qw(no_plan);
+
+use BarnOwl;
+
+# Test that casefold_principal gets it right.
+#
+# NB(jgross): I got it wrong enough times writing it that I figured
+# putting in a test case for it was worth it.
+
+sub combine_user_realm {
+    my ($user, $realm) = @_;
+    return $user . '@' . $realm if defined $realm and $realm ne '';
+    return $user;
+}
+
+sub test_casefold_principal {
+    my ($user, $realm) = @_;
+    is(BarnOwl::Message::Zephyr::casefold_principal(combine_user_realm($user, $realm)),
+       combine_user_realm(lc($user), uc($realm)));
+}
+
+test_casefold_principal('');
+test_casefold_principal('FOO');
+test_casefold_principal('FOO', 'athena.mit.edu');
+test_casefold_principal('FOO@BAR', 'athena.mit.edu');
+test_casefold_principal('', 'athena.mit.edu');
+
+1;
+

--- a/t/BarnOwl_Message_Zephyr.t
+++ b/t/BarnOwl_Message_Zephyr.t
@@ -23,8 +23,8 @@ sub test_casefold_principal {
        combine_user_realm(lc($user), uc($realm)));
 }
 
-test_casefold_principal('');
-test_casefold_principal('FOO');
+test_casefold_principal('', '');
+test_casefold_principal('FOO', '');
 test_casefold_principal('FOO', 'athena.mit.edu');
 test_casefold_principal('FOO@BAR', 'athena.mit.edu');
 test_casefold_principal('', 'athena.mit.edu');

--- a/tester.c
+++ b/tester.c
@@ -356,8 +356,8 @@ int owl_variable_regtest(void) {
   FAIL_UNLESS("get bool 6", 0 == owl_variable_get_bool(var));
 
 
-  FAIL_UNLESS("get string var", NULL != (var = owl_variable_get_var(&vd, "logpath")));
-  FAIL_UNLESS("get string", 0 == strcmp("~/zlog/people", owl_variable_get_string(var)));
+  FAIL_UNLESS("get string var", NULL != (var = owl_variable_get_var(&vd, "personalbell")));
+  FAIL_UNLESS("get string", 0 == strcmp("off", owl_variable_get_string(var)));
   FAIL_UNLESS("set string 7", 0 == owl_variable_set_string(var, "whee"));
   FAIL_UNLESS("get string", !strcmp("whee", owl_variable_get_string(var)));
 

--- a/variable.c
+++ b/variable.c
@@ -135,21 +135,6 @@ void owl_variable_add_defaults(owl_vardict *vd)
   OWLVAR_BOOL( "loginsubs" /* %OwlVarStub */, 1,
 	       "load logins from .anyone on startup", "" );
 
-  OWLVAR_BOOL( "logging" /* %OwlVarStub */, 0,
-	       "turn personal logging on or off", 
-	       "If this is set to on, personal messages are\n"
-	       "logged in the directory specified\n"
-	       "by the 'logpath' variable.  The filename in that\n"
-	       "directory is derived from the sender of the message.\n" );
-
-  OWLVAR_BOOL( "classlogging" /* %OwlVarStub */, 0,
-	       "turn class logging on or off",
-	       "If this is set to on, class messages are\n"
-	       "logged in the directory specified\n"
-	       "by the 'classlogpath' variable.\n" 
-	       "The filename in that directory is derived from\n"
-	       "the name of the class to which the message was sent.\n" );
-
   OWLVAR_ENUM( "loggingdirection" /* %OwlVarStub */, OWL_LOGGING_DIRECTION_BOTH,
 	       "specifies which kind of messages should be logged",
 	       "Can be one of 'both', 'in', or 'out'.  If 'in' is\n"
@@ -184,21 +169,6 @@ void owl_variable_add_defaults(owl_vardict *vd)
   OWLVAR_BOOL( "ignorelogins" /* %OwlVarStub */, 0,
 	       "Enable printing of login notifications",
 	       "When this is enabled, BarnOwl will print login and logout notifications\n"
-	       "for AIM, zephyr, or other protocols.  If disabled BarnOwl will not print\n"
-	       "login or logout notifications.\n");
-
-  OWLVAR_STRING( "logfilter" /* %OwlVarStub */, "",
-		 "name of a filter controlling which messages to log",
-
-		 "If non empty, any messages matching the given filter will be logged.\n"
-		 "This is a completely separate mechanism from the other logging\n"
-		 "variables like logging, classlogging, loglogins, loggingdirection,\n"
-		 "etc.  If you want this variable to control all logging, make sure\n"
-		 "all other logging variables are in their default state.\n");
-
-  OWLVAR_BOOL( "loglogins" /* %OwlVarStub */, 0,
-	       "Enable logging of login notifications",
-	       "When this is enabled, BarnOwl will log login and logout notifications\n"
 	       "for AIM, zephyr, or other protocols.  If disabled BarnOwl will not print\n"
 	       "login or logout notifications.\n");
 

--- a/variable.c
+++ b/variable.c
@@ -135,15 +135,6 @@ void owl_variable_add_defaults(owl_vardict *vd)
   OWLVAR_BOOL( "loginsubs" /* %OwlVarStub */, 1,
 	       "load logins from .anyone on startup", "" );
 
-  OWLVAR_ENUM( "loggingdirection" /* %OwlVarStub */, OWL_LOGGING_DIRECTION_BOTH,
-	       "specifies which kind of messages should be logged",
-	       "Can be one of 'both', 'in', or 'out'.  If 'in' is\n"
-	       "selected, only incoming messages are logged, if 'out'\n"
-	       "is selected only outgoing messages are logged.  If 'both'\n"
-	       "is selected both incoming and outgoing messages are\n"
-	       "logged.",
-	       "both,in,out");
-
   OWLVAR_BOOL_FULL( "colorztext" /* %OwlVarStub */, 1,
                     "allow @color() in zephyrs to change color",
                     "", NULL, owl_variable_colorztext_set, NULL);
@@ -183,16 +174,6 @@ void owl_variable_add_defaults(owl_vardict *vd)
 		    "in the editmulti keymap.\n",
 		    "off,middle,on",
 		    NULL, owl_variable_disable_ctrl_d_set, NULL);
-
-  OWLVAR_PATH( "logpath" /* %OwlVarStub */, "~/zlog/people",
-	       "path for logging personal zephyrs", 
-	       "Specifies a directory which must exist.\n"
-	       "Files will be created in the directory for each sender.\n");
-
-  OWLVAR_PATH( "classlogpath" /* %OwlVarStub:classlogpath */, "~/zlog/class",
-	       "path for logging class zephyrs",
-	       "Specifies a directory which must exist.\n"
-	       "Files will be created in the directory for each class.\n");
 
   OWLVAR_PATH( "debug_file" /* %OwlVarStub */, OWL_DEBUG_FILE,
 	       "path for logging debug messages when debugging is enabled",


### PR DESCRIPTION
Move the un-threaded portion of logging code (which is most of it) to perl.  Logging is now more uniform across modules, and more customizable.

There are two potentially semi-major decisions left to be made; one is about how permissive to be in filenames of logging files, marked in the code as

``` perl
# The original C code also removed characters less than '!'
# and greater than or equal to '~', marked file names
# beginning with a non-alphanumeric or non-ASCII character as
# 'weird', and rejected filenames longer than 35 characters.
```

The other is whether or not to include the ability to log admin messages.  I have a branch https://github.com/JasonGross/barnowl/tree/admin-logging which does this; however, it causes some error spew when BarnOwl starts up; the splash message is sent before we have enough perl machinery set up to deal with variables created in perl.

Currently, my position is:
- I like the ability to sanely log classes such as `☃`.  I'm open to restricting the filenames a bit more (such as additionally removing `!`, or `DEL` (%127), but I'd prefer not to remove all unicode from the filename.
- I'll keep the commit that adds the ability to log admin messages around in my github fork, but not in this pull request, and only work on it if I'm bored or if there's demand.

Additionally, there might be a better way to do the equivalent of `owl_util_makepath` in perl than stuffing it in `perlglue.xs`.  See the commit message for "Made owl_util_makepath available from perl" (currently 1cb06f67473019dbac02eb391b3f671a2eb00ffa) for more details.
