### PR TITLE
Clamp the number of color pairs even on ncurses ABI 6 

### DIFF
--- a/util.c
+++ b/util.c
@@ -731,7 +731,9 @@ int owl_util_get_colorpairs(void) {
    * ncurses is compiled without ext-color. */
   return MIN(COLOR_PAIRS, 256);
 #else
-  return COLOR_PAIRS;
+  /* TODO: Fix the rest of our code to handle color pairs past 256 and
+   * ext-color. */
+  return MIN(COLOR_PAIRS, 256);
 #endif
 }
 


### PR DESCRIPTION
We should be able to handle color pairs past 256 on ABI 6 (which is most
distributions but Debian-based ones<del>; even oliver has it</del><ins>(Actually it's our bundled ncurses that has it. But Fedora at least does turn it on.)</ins>), but there are
more changes that need to be done. We cannot use COLOR_PAIR() and OR it
into an attr_t. This means we also can't use wbkgdset and must use
wbkgrdset and setcchar, but that does not seem to be sufficient. It's
possible ncurses is buggy here.

For now, just use the same hack as, either way, we are not ready for
ext-colors yet.
