### PR TITLE
Use wbkgrndset instead of wbkgdset in _owl_fmtext_wcolor_set

### DIFF
--- a/fmtext.c
+++ b/fmtext.c
@@ -185,9 +185,16 @@ static void _owl_fmtext_wattrset(WINDOW *w, int attrs)
 
 static void _owl_fmtext_wcolor_set(WINDOW *w, short pair)
 {
+  cchar_t background;
+  wchar_t blank[2];
   if (has_colors()) {
-      wcolor_set(w,pair,NULL);
-      wbkgdset(w, COLOR_PAIR(pair));
+      wcolor_set(w, pair, NULL);
+      /* Set the background with wbkgrndset so that we can handle color-pairs
+       * past 256 on ncurses ABI 6 and later. */
+      blank[0] = ' ';
+      blank[1] = 0;
+      setcchar(&background, blank, 0, pair, NULL);
+      wbkgrndset(w, &background);
   }
 }
 


### PR DESCRIPTION
This allows color pairs past 255 in an ext-color-enabled build to work.
In theory anyway. Turns out ncurses is buggy and setcchar doesn't work,
but when the patch is accepted upstream we can update the ncurses in the
locker.

If we want, I also have a branch to detect the setcchar bug at runtime and clamp COLOR_PAIRS to 256 when it happens, but that's possibly overkill since, of the locker builds, it only affects i386_rhel4 and sun4x_510 (where we can push a newer ncurses). The number of people building their own BarnOwl on non-Debian-based machines running in 256-color mode is probably pretty low. Not so low on Debian, but by the time they turn on ext-color, if ever, the patch will probably have trickled through.
