### PR TITLE
Fix up headers

### DIFF
--- a/aim.c
+++ b/aim.c
@@ -1,6 +1,3 @@
-#include <stdio.h>
-#include <stdio.h>
-#include <sys/stat.h>
 #include "owl.h"
 
 /**********************************************************************/

--- a/cmd.c
+++ b/cmd.c
@@ -1,7 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 #include "owl.h"
 
 /**************************************************************************/

--- a/commands.c
+++ b/commands.c
@@ -1,9 +1,5 @@
-#include <getopt.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 #include "owl.h"
+#include <getopt.h>
 
 /* fn is "char *foo(int argc, const char *const *argv, const char *buff)" */
 #define OWLCMD_ARGS(name, fn, ctx, summary, usage, description) \

--- a/context.c
+++ b/context.c
@@ -1,4 +1,3 @@
-#include <string.h>
 #include "owl.h"
 
 #define SET_ACTIVE(ctx, new) ctx->mode = ((ctx->mode)&~OWL_CTX_ACTIVE_BITS)|new

--- a/dict.c
+++ b/dict.c
@@ -5,11 +5,7 @@
  * O(log n) on searches
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 #include "owl.h"
-
 
 #define INITSIZE 30
 #define GROWBY 3 / 2

--- a/editcontext.c
+++ b/editcontext.c
@@ -1,5 +1,4 @@
 #include "owl.h"
-
 #include <assert.h>
 
 bool owl_is_editcontext(const owl_context *ctx)

--- a/editwin.c
+++ b/editwin.c
@@ -1,8 +1,4 @@
 #include "owl.h"
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <ctype.h>
 
 #define VALID_EXCURSION	(0x9a2b4729)
 

--- a/filter.c
+++ b/filter.c
@@ -1,4 +1,3 @@
-#include <string.h>
 #include "owl.h"
 
 owl_filter *owl_filter_new_fromstring(const char *name, const char *string)

--- a/filterproc.c
+++ b/filterproc.c
@@ -1,13 +1,6 @@
-#include <signal.h>
-#include <unistd.h>
-#include <sys/select.h>
-#include <sys/types.h>
+#include "owl.h"
 #include <sys/wait.h>
 #include <poll.h>
-#include <fcntl.h>
-#include <string.h>
-
-#include <glib.h>
 
 int send_receive(int rfd, int wfd, const char *out, char **in)
 {

--- a/fmtext.c
+++ b/fmtext.c
@@ -1,6 +1,4 @@
 #include "owl.h"
-#include <stdlib.h>
-#include <string.h>
 
 /* initialize an fmtext with no data */
 void owl_fmtext_init_null(owl_fmtext *f)

--- a/functions.c
+++ b/functions.c
@@ -1,17 +1,8 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <signal.h>
-#include <netinet/in.h>
-#include <string.h>
-#include <time.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/wait.h>
-#include <errno.h>
-#include <signal.h>
 #include "owl.h"
 #include "filterproc.h"
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
 
 CALLER_OWN char *owl_function_command(const char *cmdbuff)
 {

--- a/global.c
+++ b/global.c
@@ -1,12 +1,6 @@
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
-#include <netdb.h>
-#include <termios.h>
-#include <sys/ioctl.h>
-#include <time.h>
 #include "owl.h"
+#include <stdio.h>
+#include <sys/ioctl.h>
 
 static void _owl_global_init_windows(owl_global *g);
 

--- a/help.c
+++ b/help.c
@@ -1,5 +1,4 @@
 #include "owl.h"
-#include <string.h>
 
 void owl_help(void)
 {

--- a/keybinding.c
+++ b/keybinding.c
@@ -1,5 +1,3 @@
-#include <ctype.h>
-#include <string.h>
 #include "owl.h"
 
 /*

--- a/keymap.c
+++ b/keymap.c
@@ -1,4 +1,3 @@
-#include <string.h>
 #include "owl.h"
 
 static void _owl_keymap_format_bindings(const owl_keymap *km, owl_fmtext *fm);

--- a/keypress.c
+++ b/keypress.c
@@ -1,5 +1,3 @@
-#include <ctype.h>
-#include <string.h>
 #include "owl.h"
 
 static const struct _owl_keypress_specialmap {

--- a/logging.c
+++ b/logging.c
@@ -1,8 +1,5 @@
 #include "owl.h"
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-#include <sys/param.h>
+#include <stdio.h>
 
 typedef struct _owl_log_entry { /* noproto */
   char *filename;

--- a/message.c
+++ b/message.c
@@ -1,15 +1,7 @@
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <time.h>
 #include "owl.h"
 #include "filterproc.h"
+#include <sys/socket.h>
+#include <arpa/inet.h>
 
 static owl_fmtext_cache fmtext_cache[OWL_FMTEXT_CACHE_SIZE];
 static owl_fmtext_cache * fmtext_cache_next = fmtext_cache;

--- a/messagelist.c
+++ b/messagelist.c
@@ -1,6 +1,4 @@
 #include "owl.h"
-#include <stdlib.h>
-#include <string.h>
 
 void owl_messagelist_create(owl_messagelist *ml)
 {

--- a/owl.c
+++ b/owl.c
@@ -6,21 +6,11 @@
  *  file included with the distribution for more information.
  */
 
+#include "owl.h"
 #include <stdio.h>
-#include <unistd.h>
 #include <getopt.h>
-#include <stdlib.h>
-#include <string.h>
-#include <signal.h>
-#include <time.h>
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/time.h>
-#include <termios.h>
 #include <sys/stat.h>
 #include <locale.h>
-#include "owl.h"
-
 
 #if OWL_STDERR_REDIR
 #ifdef HAVE_SYS_IOCTL_H

--- a/owl.h
+++ b/owl.h
@@ -21,15 +21,22 @@
 #include <ncursesw/panel.h>
 #endif
 #include <sys/param.h>
+#include <sys/types.h>
+#include <ctype.h>
+#include <errno.h>
 #include <EXTERN.h>
+#include <fcntl.h>
 #include <netdb.h>
 #include <regex.h>
 #include <time.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <string.h>
 #include <termios.h>
+#include <unistd.h>
 #include "libfaim/aim.h"
 #include <wchar.h>
-#include "glib.h"
+#include <glib.h>
 #ifdef HAVE_LIBZEPHYR
 #include <zephyr/zephyr.h>
 #endif

--- a/owl_perl.h
+++ b/owl_perl.h
@@ -1,6 +1,8 @@
 #ifndef INC_BARNOWL_OWL_PERL_H
 #define INC_BARNOWL_OWL_PERL_H
 
+#include <stdio.h>
+
 #define OWL_PERL_VOID_CALL (void)POPs;
 
 /*

--- a/perlconfig.c
+++ b/perlconfig.c
@@ -1,11 +1,6 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <errno.h>
 #define OWL_PERL
 #include "owl.h"
+#include <stdio.h>
 
 extern XS(boot_BarnOwl);
 extern XS(boot_DynaLoader);

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -1,9 +1,4 @@
 /* -*- mode: c; indent-tabs-mode: t; c-basic-offset: 8 -*- */
-#ifdef HAVE_LIBZEPHYR
-#include <zephyr/zephyr.h>
-#endif
-#include <EXTERN.h>
-
 #define OWL_PERL
 #include "owl.h"
 

--- a/regex.c
+++ b/regex.c
@@ -1,4 +1,3 @@
-#include <string.h>
 #include "owl.h"
 
 void owl_regex_init(owl_regex *re)

--- a/tester.c
+++ b/tester.c
@@ -3,10 +3,7 @@
 #include "owl.h"
 #undef WINDOW
 
-#include <unistd.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #undef instr
 #include <ncursesw/curses.h>

--- a/text.c
+++ b/text.c
@@ -1,7 +1,3 @@
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <ctype.h>
 #include "owl.h"
 
 /* Returns a copy of 'in' with each line indented 'n'

--- a/util.c
+++ b/util.c
@@ -1,14 +1,7 @@
 #include "owl.h"
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <ctype.h>
 #include <pwd.h>
 #include <sys/stat.h>
-#include <sys/types.h>
-#include <assert.h>
 #include <stdarg.h>
-#include <glib.h>
 #include <glib/gstdio.h>
 #include <glib-object.h>
 

--- a/variable.c
+++ b/variable.c
@@ -1,9 +1,5 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <ctype.h>
 #include "owl.h"
+#include <stdio.h>
 
 #define OWLVAR_BOOL(name,default,summary,description) \
         { g_strdup(name), OWL_VARIABLE_BOOL, NULL, default, "on,off", g_strdup(summary), g_strdup(description), NULL, \

--- a/view.c
+++ b/view.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include "owl.h"
 
 void owl_view_create(owl_view *v, const char *name, owl_filter *f, const owl_style *s)

--- a/viewwin.c
+++ b/viewwin.c
@@ -1,4 +1,3 @@
-#include <string.h>
 #include "owl.h"
 
 #define BOTTOM_OFFSET 1

--- a/window.c
+++ b/window.c
@@ -1,7 +1,5 @@
 #include "owl.h"
 
-#include <assert.h>
-
 struct _owl_window { /*noproto*/
   GObject object;
   /* hierarchy information */

--- a/zephyr.c
+++ b/zephyr.c
@@ -1,10 +1,6 @@
-#include <stdlib.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <sys/stat.h>
-#include <string.h>
 #include "owl.h"
+#include <stdio.h>
+#include <sys/stat.h>
 
 #ifdef HAVE_LIBZEPHYR
 static GSource *owl_zephyr_event_source_new(int fd);

--- a/zwrite.c
+++ b/zwrite.c
@@ -1,7 +1,3 @@
-#include <string.h>
-#include <pwd.h>
-#include <sys/types.h>
-#include <unistd.h>
 #include "owl.h"
 
 CALLER_OWN owl_zwrite *owl_zwrite_new(const char *line)


### PR DESCRIPTION
The additions to owl.h and some of the removals were done by Alejandro Sedeño asedeno@mit.edu in commit 77a0258b3919468fc9d7f7602588ac427ab36e6c.

Notes:
- I think owl.c lost the need for sys/time.h when we punted select() in
  favor of glib's main loop.
- We don't actually need to include things like stdarg.h, stdio.h,
  glib/gstdio.h, glib-object.h.  I think they get indirectly included
  via owl.h and/or glib.h.  They're left in (or added in to) the files
  that use functions/types from them.
- I'm not entirely sure what sys/socket.h is doing in message.c.  It
  is there from the initial commit.  I suspect it might have had
  something to do with the call to getnameinfo.  message.c compiles
  without it, but
  http://pubs.opengroup.org/onlinepubs/009695399/functions/getnameinfo.html
  suggests that we're supposed to include it?  _shrugs_  I'm leaving it
  in, for now.  (Rather, I'll leave one copy of the #include in.)
