### PR TITLE
Restore correct semantics of message 'time' attribute

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -1228,7 +1228,7 @@ void G_GNUC_PRINTF(1, 2) owl_function_debugmsg(const char *fmt, ...)
 
   now = time(NULL);
 
-  tmpbuff = owl_util_time_to_timestr(localtime(&now));
+  tmpbuff = owl_util_format_time(localtime(&now));
   fprintf(file, "[%d -  %s - %lds]: ",
           (int) getpid(), tmpbuff, now - owl_global_get_starttime(&g));
   g_free(tmpbuff);
@@ -1378,6 +1378,7 @@ void owl_function_info(void)
   const owl_message *m;
   owl_fmtext fm, attrfm;
   const owl_view *v;
+  char *time;
 #ifdef HAVE_LIBZEPHYR
   const ZNotice_t *n;
 #endif
@@ -1408,7 +1409,9 @@ void owl_function_info(void)
     owl_fmtext_append_normal(&fm, "  Direction : unknown\n");
   }
 
-  owl_fmtext_appendf_normal(&fm, "  Time      : %s\n", owl_message_get_timestr(m));
+  time = owl_message_format_time(m);
+  owl_fmtext_appendf_normal(&fm, "  Time      : %s\n", time);
+  g_free(time);
 
   if (!owl_message_is_type_admin(m)) {
     owl_fmtext_appendf_normal(&fm, "  Sender    : %s\n", owl_message_get_sender(m));
@@ -1781,7 +1784,7 @@ void owl_function_status(void)
   }
   owl_fmtext_append_normal(&fm, "\n");
 
-  tmpbuff = owl_util_time_to_timestr(localtime(&start));
+  tmpbuff = owl_util_format_time(localtime(&start));
   owl_fmtext_appendf_normal(&fm, "  Startup Time: %s\n", tmpbuff);
   g_free(tmpbuff);
 
@@ -3077,7 +3080,7 @@ void owl_function_buddylist(int aim, int zephyr, const char *filename)
       b=owl_buddylist_get_buddy_n(bl, i);
       idle=owl_buddy_get_idle_time(b);
       if (idle!=0) {
-	timestr=owl_util_minutes_to_timestr(idle);
+	timestr=owl_util_format_minutes(idle);
       } else {
 	timestr=g_strdup("");
       }
@@ -3406,7 +3409,7 @@ void owl_function_log_err(const char *string)
   char *buff;
 
   now = time(NULL);
-  date = owl_util_time_to_timestr(localtime(&now));
+  date = owl_util_format_time(localtime(&now));
 
   buff = g_strdup_printf("%s %s", date, string);
 

--- a/message.c
+++ b/message.c
@@ -42,7 +42,8 @@ void owl_message_init(owl_message *m)
   
   /* save the time */
   m->time = time(NULL);
-  m->timestr = owl_util_time_to_timestr(localtime(&m->time));
+  m->timestr = g_strdup(ctime(&m->time));
+  m->timestr[strlen(m->timestr)-1] = '\0';
 
   m->fmtext = NULL;
 }
@@ -343,6 +344,11 @@ const char *owl_message_get_timestr(const owl_message *m)
 {
   if (m->timestr) return(m->timestr);
   return("");
+}
+
+CALLER_OWN char *owl_message_format_time(const owl_message *m)
+{
+  return owl_util_format_time(localtime(&m->time));
 }
 
 void owl_message_set_type_admin(owl_message *m)
@@ -792,7 +798,8 @@ void owl_message_create_from_znotice(owl_message *m, const ZNotice_t *n)
   /* save the time, we need to nuke the string saved by message_init */
   if (m->timestr) g_free(m->timestr);
   m->time = n->z_time.tv_sec;
-  m->timestr = owl_util_time_to_timestr(localtime(&m->time));
+  m->timestr = g_strdup(ctime(&m->time));
+  m->timestr[strlen(m->timestr)-1] = '\0';
 
   /* set other info */
   owl_message_set_sender(m, n->z_sender);

--- a/util.c
+++ b/util.c
@@ -267,7 +267,7 @@ CALLER_OWN char *owl_arg_quote(const char *arg)
 }
 
 /* caller must free the return */
-CALLER_OWN char *owl_util_minutes_to_timestr(int in)
+CALLER_OWN char *owl_util_format_minutes(int in)
 {
   int days, hours;
   long run;
@@ -288,7 +288,7 @@ CALLER_OWN char *owl_util_minutes_to_timestr(int in)
   return(out);
 }
 
-CALLER_OWN char *owl_util_time_to_timestr(const struct tm *time)
+CALLER_OWN char *owl_util_format_time(const struct tm *time)
 {
   /* 32 chosen for first attempt because timestr will end up being
    * something like "Www Mmm dd hh:mm:ss AM yyyy UTC\0" */ 


### PR DESCRIPTION
This rewrites part of 4ebbfbc5360fa004637dd101f5a0c833cdccd60a. We can't
replace every instance of ctime with a user-formatted time, as the time
attribute is not user-formatted. It is (unfortunately) the API for perl
to override the timestamp and owl_perlconfig_hashref2message expects a
particular format for strptime. We should not then flip the values
around once they reach C. (Especially not a locale-dependent one.)

Rename __to_timestr functions to owl_util_format__ so it is clear the
function should only be used for user-formatted times.
