### PR TITLE
Switch to interactive context before sourcing the startup file

### DIFF
--- a/owl.c
+++ b/owl.c
@@ -584,6 +584,11 @@ int main(int argc, char **argv, char **env)
     "-----------------------------------------------------------------m-m---\n"
   );
 
+  owl_function_debugmsg("startup: setting context interactive");
+
+  owl_global_pop_context(&g);
+  owl_global_push_context(&g, OWL_CTX_INTERACTIVE|OWL_CTX_RECV, NULL, "recv", NULL);
+
   /* process the startup file */
   owl_function_debugmsg("startup: processing startup file");
   owl_function_source(NULL);
@@ -594,11 +599,6 @@ int main(int argc, char **argv, char **env)
       owl_view_set_style(owl_global_get_current_view(&g), s);
   else
       owl_function_error("No such style: %s", owl_global_get_default_style(&g));
-
-  owl_function_debugmsg("startup: setting context interactive");
-
-  owl_global_pop_context(&g);
-  owl_global_push_context(&g, OWL_CTX_INTERACTIVE|OWL_CTX_RECV, NULL, "recv", NULL);
 
   source = owl_window_redraw_source_new();
   g_source_attach(source, NULL);


### PR DESCRIPTION
There are no invariants that don't hold before the previous place we
flip the interactive bit; although `default_style` is applied afterwards,
there is still a style set before that code.

There is no code which reads the `READCONFIG` bit, so no behavior should
change from there. Setting the interactive bit makes
`owl_function_load{login,}subs` noisier, but that's fine. A number of
commands were labeled `OWL_CTX_INTERACTIVE`, but that doesn't change much
because, unless the command is `OWLCMD_*_CTX`, the bits are ignored.

What does change is that `.owl/startup` is allowed to leave with a context
on the stack. In particular, this /finally/ fixes #161.

More fundamentally, this makes `.owl/startup` identical to the user having
run those commands in succession, which is a nice simplification.
