### PR TITLE
rename default config file to .owl/init.pl

### DIFF
--- a/doc/barnowl.1
+++ b/doc/barnowl.1
@@ -34,8 +34,14 @@ subscribes to the default subscriptions and to anything found in
 
 .TP
 \fB\-c\fP, \fB\-\-config\-file\fP=\fIFILE\fP
-Specify an alternate config file for \fBBarnOwl\fP to use.  By default,
-\fBBarnOwl\fP uses \fI~/.barnowlconf\fP if it exists, and \fI~/.owlconf\fP otherwise.
+Specify an alternate config file for \fBBarnOwl\fP to use.  The config file is
+an arbitrary Perl script evaluated in the \fImain\fP package, and if it 
+overrides the \fIBarnOwl::startup\fP method that is run when \fBBarnOwl\fP 
+starts.  (Compare \fI~/.owl/startup\fP, which contains \fBBarnOwl\fP commands 
+that are run at startup after the config file is loaded.)
+
+By default, \fBBarnOwl\fP uses the first of \fI~/.owl/init.pl\fP, 
+\fI~/.barnowlconf\fP, or \fI~/.owlconf\fP that exists.
 
 .TP
 \fB\-s\fP, \fB\-\-config\-dir\fP=\fIDIR\fP

--- a/owl.c
+++ b/owl.c
@@ -40,8 +40,8 @@ void usage(void)
   fprintf(stderr, "  -d,--debug          enable debugging\n");
   fprintf(stderr, "  -v,--version        print the Barnowl version number and exit\n");
   fprintf(stderr, "  -h,--help           print this help message\n");
-  fprintf(stderr, "  -c,--config-file    specify an alternate config file\n");
   fprintf(stderr, "  -s,--config-dir     specify an alternate config dir (default ~/.owl)\n");
+  fprintf(stderr, "  -c,--config-file    specify an alternate config file (default ~/.owl/init.pl)\n");
   fprintf(stderr, "  -t,--tty            set the tty name\n");
 }
 

--- a/perl/lib/BarnOwl.pm
+++ b/perl/lib/BarnOwl.pm
@@ -328,10 +328,15 @@ our $configfile;
 
 our @all_commands;
 
-if(!$configfile && -f $ENV{HOME} . "/.barnowlconf") {
-    $configfile = $ENV{HOME} . "/.barnowlconf";
+if(!$configfile) {
+    if (-f get_config_dir() . "/init.pl") {
+        $configfile = get_config_dir() . "/init.pl";
+    } elsif (-f $ENV{HOME} . "/.barnowlconf") {
+        $configfile = $ENV{HOME} . "/.barnowlconf";
+    } else {
+        $configfile = $ENV{HOME}."/.owlconf";
+    }
 }
-$configfile ||= $ENV{HOME}."/.owlconf";
 
 # populate global variable space for legacy owlconf files
 sub _receive_msg_legacy_wrap {


### PR DESCRIPTION
motivations: to make clear that the config file is a perl script, which
runs before and is neither shadowed nor superceded by .owl/startup.

Per discussion from https://github.com/nelhage/barnowl-devutils/pull/1#issuecomment-2118665
