### PR TITLE
If zcrypt fails to decrypt, strip away the zcrypt opcode

### DIFF
--- a/message.c
+++ b/message.c
@@ -880,7 +880,7 @@ void owl_message_create_from_znotice(owl_message *m, const ZNotice_t *n)
       "-i", owl_message_get_instance(m),
       NULL
     };
-    char *out;
+    char *out = NULL;
     int rv;
     int status;
     char *zcrypt;
@@ -897,10 +897,12 @@ void owl_message_create_from_znotice(owl_message *m, const ZNotice_t *n)
         out[len - 8] = 0;
       }
       owl_message_set_body(m, out);
-      g_free(out);
-    } else if(out) {
-      g_free(out);
+    } else {
+      /* Replace the opcode. Otherwise the UI and other bits of code think the
+       * message was encrypted. */
+      owl_message_set_opcode(m, "failed-decrypt");
     }
+    g_free(out);
   }
 
   owl_message_save_ccs(m);


### PR DESCRIPTION
Otherwise you can make a message look encrypted by sending it with a
faked 'crypt' opcode. It also confuses the reply command. Replace it
with 'failed-decrypt' just so it shows up in the UI somehow. Perhaps
someone can write perl code to retry zcrypt on all messages with that
opcode.

Also has the side effect of marking gibberish so the user has some hope
of realizing what happened if they sub to a zcrypted class without the
key.

And initialize out to NULL since there's actually a codepath where that
value never gets set.

Reported-by: Melissa Hunt wings@mit.edu
