### PR TITLE
Include names of invalid filters

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -2185,7 +2185,7 @@ bool owl_function_create_filter(int argc, const char *const *argv)
   /* create the filter and check for errors */
   f = owl_filter_new(argv[1], argc-2, argv+2);
   if (f == NULL) {
-    owl_function_error("Invalid filter");
+    owl_function_error("Invalid filter: %s", argv[1]);
     return false;
   }
 


### PR DESCRIPTION
This makes errors in filters defined in startup files easier to find.
Otherwise, figuring out the name can be hard.

(I'm not totally sure about how to word this, since it will usually (presumably) show up interactively, in which case the name is pretty obvious. Thoughts are appreciated.)
