### PR TITLE
Use Digest::SHA in Jabber module instead of Digest::SHA1

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ The Jabber module requires:
 Net::DNS
 Authen::SASL::Perl
 IO::Socket::SSL
-Digest::SHA1
+Digest::SHA
 
 The Twitter module requires:
 

--- a/perl/modules/Jabber/lib/Net/Jabber/Component.pm
+++ b/perl/modules/Jabber/lib/Net/Jabber/Component.pm
@@ -219,7 +219,7 @@ sub _auth
     
     $self->{STREAM}->SetCallBacks(node=>undef);
 
-    $self->Send("<handshake>".Digest::SHA1::sha1_hex($self->{SESSION}->{id}.$args{secret})."</handshake>");
+    $self->Send("<handshake>".Digest::SHA::sha1_hex($self->{SESSION}->{id}.$args{secret})."</handshake>");
     my $handshake = $self->Process();
 
     if (!defined($handshake) ||

--- a/perl/modules/Jabber/lib/Net/Jabber/Key.pm
+++ b/perl/modules/Jabber/lib/Net/Jabber/Key.pm
@@ -103,14 +103,14 @@ sub new
     
     $self->{CACHE} = {};
 
-    if (eval "require Digest::SHA1")
+    if (eval "require Digest::SHA")
     {
         $self->{DIGEST} = 1;
-        Digest::SHA1->import(qw(sha1 sha1_hex sha1_base64));
+        Digest::SHA->import(qw(sha1 sha1_hex sha1_base64));
     }
     else
     {
-        print "ERROR:  You cannot use Key.pm unless you have Digest::SHA1 installed.\n";
+        print "ERROR:  You cannot use Key.pm unless you have Digest::SHA installed.\n";
         exit(0);
     }
 
@@ -131,7 +131,7 @@ sub Generate
     my $self = shift;
 
     my $string = $$.time.rand(1000000);
-    $string = Digest::SHA1::sha1_hex($string);
+    $string = Digest::SHA::sha1_hex($string);
     $self->{DEBUG}->Log1("Generate: key($string)");
     return $string;
 }

--- a/perl/modules/Jabber/lib/Net/XMPP.pm
+++ b/perl/modules/Jabber/lib/Net/XMPP.pm
@@ -212,7 +212,7 @@ use strict;
 use XML::Stream 1.22 qw( Node );
 use Time::Local;
 use Carp;
-use Digest::SHA1;
+use Digest::SHA;
 use Authen::SASL;
 use MIME::Base64;
 use POSIX;

--- a/perl/modules/Jabber/lib/Net/XMPP/Protocol.pm
+++ b/perl/modules/Jabber/lib/Net/XMPP/Protocol.pm
@@ -1848,12 +1848,12 @@ sub AuthIQAuth
     #--------------------------------------------------------------------------
     if ($authType eq "zerok")
     {
-        my $hashA = Digest::SHA1::sha1_hex($password);
-        $args{hash} = Digest::SHA1::sha1_hex($hashA.$token);
+        my $hashA = Digest::SHA::sha1_hex($password);
+        $args{hash} = Digest::SHA::sha1_hex($hashA.$token);
 
         for (1..$sequence)
         {
-            $args{hash} = Digest::SHA1::sha1_hex($args{hash});
+            $args{hash} = Digest::SHA::sha1_hex($args{hash});
         }
     }
 
@@ -1867,7 +1867,7 @@ sub AuthIQAuth
     #--------------------------------------------------------------------------
     if ($authType eq "digest")
     {
-        $args{digest} = Digest::SHA1::sha1_hex($self->GetStreamID().$password);
+        $args{digest} = Digest::SHA::sha1_hex($self->GetStreamID().$password);
     }
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
The cool kids spell it without the 1 these days. More precisely,
Digest::SHA1 no longer exists in precise. Also it's in perl itself these
days.

(We can just install Digest::SHA into the locker for the sysnames that
need it.)
