### PR TITLE
implement :renew

### DIFF
--- a/perl/modules/Kerberos/Makefile.PL
+++ b/perl/modules/Kerberos/Makefile.PL
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+
+use inc::Module::Install;
+
+barnowl_module('Kerberos');
+
+WriteAll;

--- a/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
+++ b/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
@@ -64,10 +64,7 @@ sub cmd_renew {
 
 my $hdlin;
 my $hdlerr;
-my $w;
-
-my $a_hdlerr;
-my $a;
+my $kinit_watcher;
 
 sub do_renew {
 
@@ -87,7 +84,7 @@ sub do_renew {
         $output .= $line;
                      });
     close $stdout;
-    $w = AnyEvent->child (pid => $pid, cb => sub {
+    $kinit_watcher = AnyEvent->child (pid => $pid, cb => sub {
         my ($pid, $status) = @_;
         if ($status != 0){
             BarnOwl::error($output);

--- a/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
+++ b/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
@@ -1,0 +1,108 @@
+use strict;
+use warnings;
+
+package BarnOwl::Module::Kerberos;
+
+=head1 NAME
+
+BarnOwl::Module::Kerberos
+
+=head1 DESCRIPTION
+
+This module allows someone to renew tickets withing barnowl
+
+=cut
+
+use BarnOwl;
+use AnyEvent;
+use AnyEvent::Handle;
+use IPC::Open3;
+
+use Data::Dumper;
+
+our $VERSION = 1.0;
+
+BarnOwl::new_variable_bool(
+    'aklog',
+    {
+        default => 1,
+        summary => 'Enable running aklog on renew',
+        description => "If set, aklog will be run during the renew command."
+     }
+ );
+
+sub startup {
+    register_commands();
+}
+
+sub register_commands {
+    BarnOwl::new_command(
+        'renew' => \&cmd_renew,
+        {
+            summary => 'Renew Kerberos Tickets',
+            usage => 'renew',
+            description => <<END_DESCR
+Renews Kerberos Ticket
+END_DESCR
+        }
+    );
+}
+
+
+$BarnOwl::Hooks::startup->add('BarnOwl::Module::Kerberos::startup');
+
+################################################################################
+######################## Owl command handlers ##################################
+################################################################################
+
+
+sub cmd_renew {
+    BarnOwl::start_password("Password: ", \&do_renew );
+    return "";
+}
+
+
+my $hdlin;
+my $hdlerr;
+my $w;
+
+my $a_hdlerr;
+my $a;
+
+sub do_renew {
+
+    my $password = shift;
+    my($stdin, $stdout, $stderr);
+    use Symbol 'gensym'; $stderr = gensym;
+    my $pid = open3($stdin, $stdout, $stderr, 'kinit', '-l7d') or die("Failed to run kinit");
+
+    $hdlerr = new AnyEvent::Handle(fh => $stderr);
+    $hdlin = new AnyEvent::Handle(fh => $stdin);
+
+    my $output = "";
+
+    $hdlin->push_write($password .  "\n");
+    $hdlerr->push_read (line => sub {
+        my ($hdl, $line) = @_;
+        $output .= $line;
+                     });
+    close $stdout;
+    $w = AnyEvent->child (pid => $pid, cb => sub {
+        my ($pid, $status) = @_;
+        if ($status != 0){
+            BarnOwl::error($output);
+        }
+        else{
+            if(BarnOwl::getvar("aklog") == 'on'){
+                my $status = system('aklog');
+                if ($status != 0){
+                    BarnOwl::error('Aklog Failed');
+                }
+            }
+        }
+    });
+
+}
+
+
+1;

--- a/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
+++ b/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
@@ -9,7 +9,7 @@ BarnOwl::Module::Kerberos
 
 =head1 DESCRIPTION
 
-This module allows someone to renew tickets withing barnowl
+This module allows someone to renew tickets within BarnOwl
 
 =cut
 

--- a/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
+++ b/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
@@ -69,7 +69,7 @@ my $kinit_watcher;
 sub do_renew {
 
     my $password = shift;
-    my($stdin, $stdout, $stderr);
+    my ($stdin, $stdout, $stderr);
     use Symbol 'gensym'; $stderr = gensym;
     my $pid = open3($stdin, $stdout, $stderr, 'kinit', '-l7d') or die("Failed to run kinit");
 
@@ -79,20 +79,19 @@ sub do_renew {
     my $output = "";
 
     $hdlin->push_write($password .  "\n");
-    $hdlerr->push_read (line => sub {
+    $hdlerr->push_read(line => sub {
         my ($hdl, $line) = @_;
         $output .= $line;
                      });
     close $stdout;
     $kinit_watcher = AnyEvent->child (pid => $pid, cb => sub {
         my ($pid, $status) = @_;
-        if ($status != 0){
+        if ($status != 0) {
             BarnOwl::error($output);
-        }
-        else{
-            if(BarnOwl::getvar("aklog") == 'on'){
+        } else {
+            if (BarnOwl::getvar("aklog") == 'on') {
                 my $status = system('aklog');
-                if ($status != 0){
+                if ($status != 0) {
                     BarnOwl::error('Aklog Failed');
                 }
             }

--- a/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
+++ b/perl/modules/Kerberos/lib/BarnOwl/Module/Kerberos.pm
@@ -89,7 +89,7 @@ sub do_renew {
         if ($status != 0) {
             BarnOwl::error($output);
         } else {
-            if (BarnOwl::getvar("aklog") == 'on') {
+            if (BarnOwl::getvar("aklog") eq 'on') {
                 my $status = system('aklog');
                 if ($status != 0) {
                     BarnOwl::error('Aklog Failed');

--- a/perl/modules/Makefile.am
+++ b/perl/modules/Makefile.am
@@ -1,4 +1,4 @@
-MODULES = Jabber IRC WordWrap Twitter Facebook
+MODULES = Jabber IRC WordWrap Twitter Facebook Kerberos
 
 EXTRA_DIST = $(MODULES:=/Makefile.PL) $(MODULES:=/lib)
 EXTRA_DIST += \


### PR DESCRIPTION
Using barnowl frequently generally requires a version of screen this patch inserts
a modified version of kchen's owl-screen and related utilities to make it easier for
users with little linux technical knowledge to start using screen with barnowl.
