### PR TITLE
Fix display of pseudologins

### DIFF
--- a/perl/lib/BarnOwl/Message/Zephyr.pm
+++ b/perl/lib/BarnOwl/Message/Zephyr.pm
@@ -50,12 +50,14 @@ sub subcontext {
 sub login_tty {
     my ($m) = @_;
     return undef if (!$m->is_loginout);
+    return undef if (!defined($m->fields));
     return $m->fields->[2];
 }
 
 sub login_host {
     my ($m) = @_;
     return undef if (!$m->is_loginout);
+    return undef if (!defined($m->fields));
     return $m->fields->[0];
 }
 


### PR DESCRIPTION
After b9517cf7ce2959a6e86a52d25a98b1d03df56d58, they lost fields keys.
Given that they're faked and the old behavior was reading an
uninitialized ZNotice_t or something, let's keep that key undefined and
fix the two places that use it.

Reported-By: Kevin Chen kchen@mit.edu
