### PR TITLE
zcrypt: Make gpg stop messing around in ~/.gnupg

### DIFF
--- a/zcrypt.c
+++ b/zcrypt.c
@@ -765,6 +765,10 @@ int do_encrypt_aes(const char *keyfile, const char *in, int length, FILE *outfil
   const char *argv[] = {
     "gpg",
     "--symmetric",
+    "--no-options",
+    "--no-default-keyring",
+    "--keyring", "/dev/null",
+    "--secret-keyring", "/dev/null",
     "--batch",
     "--quiet",
     "--no-use-agent",
@@ -845,6 +849,10 @@ int do_decrypt_aes(const char *keyfile) {
   const char *argv[] = {
     "gpg",
     "--decrypt",
+    "--no-options",
+    "--no-default-keyring",
+    "--keyring", "/dev/null",
+    "--secret-keyring", "/dev/null",
     "--batch",
     "--no-use-agent",
     "--quiet",


### PR DESCRIPTION
Signed-off-by: Anders Kaseorg andersk@mit.edu
