### PR TITLE
Defer failed log messages

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -487,12 +487,20 @@ void owl_cmd_add_defaults(owl_cmddict *cd)
 	      "\n"
 	      "SEE ALSO: aaway, zaway"),
 
-  OWLCMD_VOID("flush-logs", owl_command_flushlogs, OWL_CTX_ANY,
+  OWLCMD_ARGS("flush-logs", owl_command_flushlogs, OWL_CTX_ANY,
               "flush the queue of messages waiting to be logged",
-              "",
+              "flush-logs [-f | --force]",
               "If BarnOwl failed to log a file, this command tells\n"
               "BarnOwl to try logging the messages that have since\n"
-              "come in, and to resume logging normally."),
+              "come in, and to resume logging normally.\n"
+              "\n"
+              "Normally, if logging any of these messages fails,\n"
+              "that message is added to the queue of messages waiting\n"
+              "to be logged, and any new messages are deferred until\n"
+              "the next :flush-logs.  If the --force flag is passed,\n"
+              "any messages on the queue which cannot successfully be\n"
+              "logged are dropped, and BarnOwl will resume logging\n"
+              "normally."),
 
   OWLCMD_ARGS("load-subs", owl_command_loadsubs, OWL_CTX_ANY,
 	      "load subscriptions from a file",
@@ -1443,9 +1451,20 @@ void owl_command_unsuball(void)
   owl_function_unsuball();
 }
 
-void owl_command_flushlogs(void)
+char *owl_command_flushlogs(int argc, const char *const *argv, const char *buff)
 {
-  owl_log_flush_logs();
+  if (argc == 1) {
+    owl_log_flush_logs(false);
+  } else if (argc == 2) {
+    if (!strcmp(argv[1], "-f") || !strcmp(argv[1], "--force")) {
+      owl_log_flush_logs(true);
+    } else {
+      owl_function_makemsg("Invalid flag to flush-logs: %s", argv[1]);
+    }
+  } else {
+    owl_function_makemsg("Wrong number of arguments for flush-logs.");
+  }
+  return NULL;
 }
 
 char *owl_command_loadsubs(int argc, const char *const *argv, const char *buff)

--- a/commands.c
+++ b/commands.c
@@ -489,7 +489,7 @@ void owl_cmd_add_defaults(owl_cmddict *cd)
 
   OWLCMD_ARGS("flush-logs", owl_command_flushlogs, OWL_CTX_ANY,
               "flush the queue of messages waiting to be logged",
-              "flush-logs [-f | --force]",
+              "flush-logs [-f | --force] [-q | --quiet]",
               "If BarnOwl failed to log a file, this command tells\n"
               "BarnOwl to try logging the messages that have since\n"
               "come in, and to resume logging normally.\n"
@@ -500,7 +500,10 @@ void owl_cmd_add_defaults(owl_cmddict *cd)
               "the next :flush-logs.  If the --force flag is passed,\n"
               "any messages on the queue which cannot successfully be\n"
               "logged are dropped, and BarnOwl will resume logging\n"
-              "normally."),
+              "normally.\n"
+              "\n"
+              "Unless --quiet is passed, a message is printed about\n"
+              "how many logs there are to flush."),
 
   OWLCMD_ARGS("load-subs", owl_command_loadsubs, OWL_CTX_ANY,
 	      "load subscriptions from a file",
@@ -1453,17 +1456,20 @@ void owl_command_unsuball(void)
 
 char *owl_command_flushlogs(int argc, const char *const *argv, const char *buff)
 {
-  if (argc == 1) {
-    owl_log_flush_logs(false);
-  } else if (argc == 2) {
-    if (!strcmp(argv[1], "-f") || !strcmp(argv[1], "--force")) {
-      owl_log_flush_logs(true);
+  bool force = false;
+  bool quiet = false;
+  int i;
+
+  for (i = 1; i < argc; i++) {
+    if (!strcmp(argv[i], "-f") || !strcmp(argv[i], "--force")) {
+      force = true;
+    } else if (!strcmp(argv[i], "-q") || !strcmp(argv[i], "--quiet")) {
+      quiet = true;
     } else {
-      owl_function_makemsg("Invalid flag to flush-logs: %s", argv[1]);
+      owl_function_makemsg("Invalid flag to flush-logs: %s", argv[i]);
     }
-  } else {
-    owl_function_makemsg("Wrong number of arguments for flush-logs.");
   }
+  owl_log_flush_logs(force, quiet);
   return NULL;
 }
 

--- a/commands.c
+++ b/commands.c
@@ -487,6 +487,13 @@ void owl_cmd_add_defaults(owl_cmddict *cd)
 	      "\n"
 	      "SEE ALSO: aaway, zaway"),
 
+  OWLCMD_VOID("flush-logs", owl_command_flushlogs, OWL_CTX_ANY,
+              "flush the queue of messages waiting to be logged",
+              "",
+              "If BarnOwl failed to log a file, this command tells\n"
+              "BarnOwl to try logging the messages that have since\n"
+              "come in, and to resume logging normally."),
+
   OWLCMD_ARGS("load-subs", owl_command_loadsubs, OWL_CTX_ANY,
 	      "load subscriptions from a file",
 	      "load-subs <file>\n", ""),
@@ -1434,6 +1441,11 @@ void owl_command_set_shift(int shift)
 void owl_command_unsuball(void)
 {
   owl_function_unsuball();
+}
+
+void owl_command_flushlogs(void)
+{
+  owl_log_flush_logs();
 }
 
 char *owl_command_loadsubs(int argc, const char *const *argv, const char *buff)

--- a/logging.c
+++ b/logging.c
@@ -303,7 +303,7 @@ static void owl_log_write_deferred_entries(gpointer data)
     }
     owl_log_entry_free(entry);
   }
-  if (all_succeeded && logged_at_least_one_message) {
+  if (all_succeeded && logged_at_least_one_message && !defer_logs) {
     owl_log_adminmsg("Logs have been flushed and logging has resumed.");
   }
 }

--- a/logging.c
+++ b/logging.c
@@ -150,11 +150,17 @@ static void owl_log_error_main_thread(gpointer data)
   owl_function_error("%s", (const char*)data);
 }
 
-static void owl_log_error(const char *message)
+static void G_GNUC_PRINTF(1, 2) owl_log_error(const char *fmt, ...)
 {
-  char *data = g_strdup(message);
+  va_list ap;
+  char *data;
+
+  va_start(ap, fmt);
+  data = g_strdup_vprintf(fmt, ap);
+  va_end(ap);
+
   owl_select_post_task(owl_log_error_main_thread,
-		       data, g_free, g_main_context_default());
+                       data, g_free, g_main_context_default());
 }
 
 static void owl_log_write_entry(gpointer data)
@@ -163,7 +169,7 @@ static void owl_log_write_entry(gpointer data)
   FILE *file = NULL;
   file = fopen(msg->filename, "a");
   if (!file) {
-    owl_log_error("Unable to open file for logging");
+    owl_log_error("Unable to open file for logging (%s)", msg->filename);
     return;
   }
   fprintf(file, "%s", msg->message);

--- a/logging.c
+++ b/logging.c
@@ -267,7 +267,8 @@ static void owl_log_file_error(owl_log_entry *msg, int errnum)
  * Otherwise, try to write this log message, and, if it fails with
  * EPERM, EACCES, or ETIMEDOUT, go into deferred logging mode and
  * queue an admin message.  If it fails with anything else, display an
- * error message, but do not go into deferred logging mode.
+ * error message, drop the log message, and do not go into deferred
+ * logging mode.
  *
  * N.B. This function is called only on the disk-writing thread. */
 static void owl_log_eventually_write_entry(gpointer data)

--- a/logging.c
+++ b/logging.c
@@ -256,10 +256,10 @@ static void owl_log_entry_free_gfunc(gpointer data, gpointer user_data)
 }
 #endif
 
-static void owl_log_file_error(owl_log_entry *msg, int ret)
+static void owl_log_file_error(owl_log_entry *msg, int errnum)
 {
   owl_log_error("Unable to open file for logging: %s (file %s)",
-                g_strerror(ret),
+                g_strerror(errnum),
                 msg->filename);
 }
 

--- a/logging.c
+++ b/logging.c
@@ -10,7 +10,7 @@ typedef struct _owl_log_entry { /* noproto */
 static GMainContext *log_context;
 static GMainLoop *log_loop;
 static GThread *logging_thread;
-bool defer_logs;
+static bool defer_logs;
 static GQueue *deferred_entry_queue;
 
 /* This is now the one function that should be called to log a

--- a/logging.c
+++ b/logging.c
@@ -220,9 +220,9 @@ static void owl_log_file_error(owl_log_entry *msg, int ret)
 
 /* If we are deferring log messages, enqueue this entry for writing.
  * Otherwise, try to write this log message, and, if it fails with
- * EPERM or EACCES, go into deferred logging mode and queue an admin
- * message.  If it fails with anything else, display an error message,
- * but do not go into deferred logging mode. */
+ * EPERM, EACCES, or ETIMEDOUT, go into deferred logging mode and
+ * queue an admin message.  If it fails with anything else, display an
+ * error message, but do not go into deferred logging mode. */
 static void owl_log_eventually_write_entry(gpointer data)
 {
   int ret;
@@ -231,7 +231,7 @@ static void owl_log_eventually_write_entry(gpointer data)
     owl_log_deferred_enqueue_message(msg->message, msg->filename);
   } else {
     ret = owl_log_try_write_entry(msg);
-    if (ret == EPERM || ret == EACCES) {
+    if (ret == EPERM || ret == EACCES || ret == ETIMEDOUT) {
       defer_logs = true;
       owl_log_error("Unable to open file for logging (%s): \n"
                     "%s.  \n"

--- a/perl/Makefile.am
+++ b/perl/Makefile.am
@@ -8,6 +8,7 @@ nobase_dist_pkgdata_DATA = \
 	lib/BarnOwl/Completion.pm \
 	lib/BarnOwl/Completion/Context.pm \
 	lib/BarnOwl/Completion/Util.pm \
+	lib/BarnOwl/DeferredLogging.pm \
 	lib/BarnOwl/Editwin.pm \
 	lib/BarnOwl/Help.pm \
 	lib/BarnOwl/Hook.pm \

--- a/perl/lib/BarnOwl.pm
+++ b/perl/lib/BarnOwl.pm
@@ -44,6 +44,7 @@ use BarnOwl::Timer;
 use BarnOwl::Editwin;
 use BarnOwl::Completion;
 use BarnOwl::Help;
+use BarnOwl::DeferredLogging;
 
 use List::Util qw(max);
 use Tie::RefHash;

--- a/perl/lib/BarnOwl/DeferredLogging.pm
+++ b/perl/lib/BarnOwl/DeferredLogging.pm
@@ -1,0 +1,61 @@
+use strict;
+use warnings;
+
+package BarnOwl::DeferredLogging;
+
+=head1 BarnOwl::DeferredLogging
+
+=head1 DESCRIPTION
+
+C<BarnOwl::DeferredLogging> adds variables relevant to deferred logging.
+
+=head2 USAGE
+
+Not Applicable.
+
+=head2 EXPORTS
+
+None by default.
+
+=cut
+
+use BarnOwl::Timer;
+use Exporter;
+
+our @EXPORT_OK = qw();
+
+our %EXPORT_TAGS = (all => [@EXPORT_OK]);
+
+$BarnOwl::Hooks::startup->add("BarnOwl::DeferredLogging::_register_variables");
+
+sub _register_variables {
+    my $flush_logs_interval = -1;
+    my $flush_logs_timer;
+    BarnOwl::new_variable_full('flush-logs-interval',
+        {
+            default        => -1,
+            summary        => 'how often should logs be flushed, in minutes',
+            description    => "If this is set to a positive value n, deferred logs \n"
+                            . "are flushed every n minutes.  If set to a negative or \n"
+                            . "zero values, deferred logs are only flushed when the \n"
+                            . "command :flush-logs is used.",
+            get_tostring   => sub { "$flush_logs_interval" },
+            set_fromstring => sub {
+                die "Expected integer" unless $_[0] =~ /^-?[0-9]+$/;
+                $flush_logs_interval = 0 + $_[0];
+                $flush_logs_timer->stop if defined $flush_logs_timer;
+                undef $flush_logs_timer;
+                if ($flush_logs_interval > 0) {
+                    $flush_logs_timer = BarnOwl::Timer->new({
+                            name     => 'flush-logs interval timer',
+                            interval => 60 * $flush_logs_interval,
+                            cb       => sub { BarnOwl::command("flush-logs"); }
+                        });
+                }
+            },
+            validsettings => "<int>",
+            takes_on_off => 0,
+        });
+}
+
+1;

--- a/perl/lib/BarnOwl/DeferredLogging.pm
+++ b/perl/lib/BarnOwl/DeferredLogging.pm
@@ -42,7 +42,7 @@ sub _register_variables {
             get_tostring   => sub { "$flush_logs_interval" },
             set_fromstring => sub {
                 die "Expected integer" unless $_[0] =~ /^-?[0-9]+$/;
-                $flush_logs_interval = 0 + $_[0];
+                $flush_logs_interval = $_[0];
                 $flush_logs_timer->stop if defined $flush_logs_timer;
                 undef $flush_logs_timer;
                 if ($flush_logs_interval > 0) {

--- a/perl/lib/BarnOwl/DeferredLogging.pm
+++ b/perl/lib/BarnOwl/DeferredLogging.pm
@@ -49,7 +49,7 @@ sub _register_variables {
                     $flush_logs_timer = BarnOwl::Timer->new({
                             name     => 'flush-logs interval timer',
                             interval => 60 * $flush_logs_interval,
-                            cb       => sub { BarnOwl::command("flush-logs"); }
+                            cb       => sub { BarnOwl::command("flush-logs", "-q"); }
                         });
                 }
             },

--- a/perl/lib/BarnOwl/DeferredLogging.pm
+++ b/perl/lib/BarnOwl/DeferredLogging.pm
@@ -31,6 +31,9 @@ $BarnOwl::Hooks::startup->add("BarnOwl::DeferredLogging::_register_variables");
 sub _register_variables {
     my $flush_logs_interval = -1;
     my $flush_logs_timer;
+    # N.B. We use new_variable_full rather than new_variable_int so
+    # that we can set a timer to flush logs when this value is
+    # changed.
     BarnOwl::new_variable_full('flush-logs-interval',
         {
             default        => 60,

--- a/perl/lib/BarnOwl/DeferredLogging.pm
+++ b/perl/lib/BarnOwl/DeferredLogging.pm
@@ -33,7 +33,7 @@ sub _register_variables {
     my $flush_logs_timer;
     BarnOwl::new_variable_full('flush-logs-interval',
         {
-            default        => -1,
+            default        => 60,
             summary        => 'how often should logs be flushed, in minutes',
             description    => "If this is set to a positive value n, deferred logs \n"
                             . "are flushed every n minutes.  If set to a negative or \n"


### PR DESCRIPTION
Previously, when we failed to open a logging file, we errored, and
dropped the log message.  This commit makes it so that, if the reason we
failed was a permissions error, we instead add the log entry to a queue
of messages to be logged eventually, and inform the user that logging
has been suspended.  The user must run :flush-logs to resume logging.

If :flush-log has an fopen that fails with EPERM or EACCES, we re-defer
messages and inform the user.

On shutdown, BarnOwl will attempt to log all messages currently in the
queue one last time.

TODO: Decide whether or not to include ETIMEDOUT in the deferred logging.
