### PR TITLE
Make check for non-existant channel more correct

### DIFF
--- a/perl/modules/IRC/lib/BarnOwl/Module/IRC.pm
+++ b/perl/modules/IRC/lib/BarnOwl/Module/IRC.pm
@@ -614,7 +614,7 @@ sub mk_irc_command {
             }
         }
 
-        if(!$channel &&
+        if(!defined($channel) &&
            ($flags & CHANNEL_ARG) &&
            !($flags & CHANNEL_OPTIONAL)) {
             die("Usage: $cmd <channel>\n");


### PR DESCRIPTION
Currently, this doesn't change anything; all channels start with '#'.
However, when pull #107 (Improve irc-msg support for multiple
connections) lands we want to accept, e.g., '0' as a valid user name.
So we should actually be checking if the value is defined, rather than
if it's not falsy.  I've also excluded empty strings as valid user
names/channels, which I'm not sure is the right decision.
