### PR TITLE
Revamp set/unset completion

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -152,7 +152,7 @@ void owl_cmd_add_defaults(owl_cmddict *cd)
 
   OWLCMD_ARGS("set", owl_command_set, OWL_CTX_ANY,
 	      "set a variable value",
-	      "set [-q] [<variable>] [<value>]\n"
+	      "set [-q] <variable> [<value>]\n"
 	      "set",
 	      "Set the named variable to the specified value.  If no\n"
 	      "arguments are given, print the value of all variables.\n"

--- a/perl/lib/BarnOwl/Complete/Client.pm
+++ b/perl/lib/BarnOwl/Complete/Client.pm
@@ -145,12 +145,13 @@ sub complete_getvar {
 
 sub complete_set {
     my $ctx = shift;
-    return complete_flags($ctx,
-        [qw(-q)],
-        {
-        },
-         \&complete_set_args
-        );
+    if ($ctx->word == 1) {
+        return ("-q", complete_variable());
+    }
+    if ($ctx->word == 2 && $ctx->words->[1] eq "-q") {
+        return complete_variable();
+    }
+    return;
 }
 sub complete_set_args {
     my $ctx = shift;

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -358,6 +358,34 @@ skiptokens(str, n)
 	OUTPUT:
 		RETVAL
 
+SV *
+get_variable_info(name)
+	const char *name;
+	PREINIT:
+		owl_variable *var;
+		HV *h;
+	CODE:
+		var = owl_variable_get_var(owl_global_get_vardict(&g), name);
+		if (var == NULL) {
+			croak("No such variable");
+		}
+		h = newHV();
+		(void)hv_store(h, "name", strlen("name"),
+		               owl_new_sv(owl_variable_get_name(var)), 0);
+		(void)hv_store(h, "description", strlen("description"),
+		               owl_new_sv(owl_variable_get_description(var)),
+		               0);
+		(void)hv_store(h, "summary", strlen("summary"),
+		               owl_new_sv(owl_variable_get_summary(var)), 0);
+		(void)hv_store(h, "validsettings", strlen("validsettings"),
+		               owl_new_sv(owl_variable_get_validsettings(var)),
+		               0);
+		(void)hv_store(h, "takes_on_off", strlen("takes_on_off"),
+		               newSViv(owl_variable_takes_on_off(var)), 0);
+		RETVAL = newRV_noinc((SV*)h);
+	OUTPUT:
+		RETVAL
+
 
 MODULE = BarnOwl		PACKAGE = BarnOwl::Zephyr
 

--- a/variable.c
+++ b/variable.c
@@ -801,6 +801,10 @@ const char *owl_variable_get_validsettings(const owl_variable *v) {
   return v->validsettings;
 }
 
+bool owl_variable_takes_on_off(const owl_variable *v) {
+  return v->takes_on_off;
+}
+
 int owl_variable_get_type(const owl_variable *v)
 {
   return v->type;

--- a/variable.c
+++ b/variable.c
@@ -161,7 +161,7 @@ void owl_variable_add_defaults(owl_vardict *vd)
 
   OWLVAR_BOOL_FULL( "colorztext" /* %OwlVarStub */, 1,
                     "allow @color() in zephyrs to change color",
-                    NULL, NULL, owl_variable_colorztext_set, NULL);
+                    "", NULL, owl_variable_colorztext_set, NULL);
 
   OWLVAR_BOOL( "fancylines" /* %OwlVarStub */, 1,
 	       "Use 'nice' line drawing on the terminal.",


### PR DESCRIPTION
Because I can. This branch makes it so that
- unset <tab> only completes takes_on_off variables
- Variables with validsettings <path> complete as file paths
- Variables with validsettings a comma-separated list of options complete appropriately.
