### PR TITLE
call_filter: Set *out = NULL on g_spawn_async_with_pipes failure

### DIFF
--- a/filterproc.c
+++ b/filterproc.c
@@ -80,6 +80,7 @@ int call_filter(const char *const *argv, const char *in, char **out, int *status
                                 NULL, NULL,
                                 &child_pid, &child_stdin, &child_stdout, NULL,
                                 NULL)) {
+    *out = NULL;
     return 1;
   }
 


### PR DESCRIPTION
Fixes a zcrypt crash.

Signed-off-by: Anders Kaseorg andersk@mit.edu
