### PR TITLE
Skip deprecated g_type_init() for GLib 2.35

### DIFF
--- a/global.c
+++ b/global.c
@@ -8,7 +8,9 @@ void owl_global_init(owl_global *g) {
   char *cd;
   const char *homedir;
 
+#if !GLIB_CHECK_VERSION(2, 35, 0)
   g_type_init();
+#endif
 #if !GLIB_CHECK_VERSION(2, 31, 0)
   g_thread_init(NULL);
 #endif


### PR DESCRIPTION
https://developer.gnome.org/gobject/2.35/gobject-Type-Information.html#g-type-init

Signed-off-by: Anders Kaseorg andersk@mit.edu
