### PR TITLE
Remove pointless ZFreeNotice

### DIFF
--- a/zephyr.c
+++ b/zephyr.c
@@ -741,7 +741,6 @@ int send_zephyr(const char *opcode, const char *zsig, const char *class, const c
   
   /* free then check the return */
   g_free(notice.z_message);
-  ZFreeNotice(&notice);
   g_free(zsender);
   if (ret != ZERR_NONE) {
     owl_function_error("Error sending zephyr: %s", error_message(ret));


### PR DESCRIPTION
It's only meant to be called on a ZNotice_t that was filled in by a libzephyr
call documented to require a ZFreeNotice. This one was filled in manually. (It
happens to not do anything because it calls free on a NULL pointer).
