### PR TITLE
Don't swallow errors in :unsuball

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -854,8 +854,8 @@ void owl_function_shift_left(void)
 
 void owl_function_unsuball(void)
 {
-  unsuball();
-  owl_function_makemsg("Unsubscribed from all messages.");
+  if (unsuball())
+    owl_function_makemsg("Unsubscribed from all messages.");
 }
 
 

--- a/zephyr.c
+++ b/zephyr.c
@@ -454,7 +454,7 @@ int owl_zephyr_loadloginsubs(const char *filename)
 #endif
 }
 
-void unsuball(void)
+bool unsuball(void)
 {
 #if HAVE_LIBZEPHYR
   Code_t ret;
@@ -464,7 +464,9 @@ void unsuball(void)
   if (ret != ZERR_NONE)
     owl_function_error("Zephyr: Cancelling subscriptions: %s",
                        error_message(ret));
+  return (ret == ZERR_NONE);
 #endif
+  return true;
 }
 
 int owl_zephyr_sub(const char *class, const char *inst, const char *recip)


### PR DESCRIPTION
More code that should get fixed if we ever use GError or some other saner error
reporting mechanism. For now, I suppose this mess with the lower-level function
reporting error and the higher-level function reporting success is in good
company.

Test by doing a kdestroy before :unsuball. It should complain about a SERVNAK.
(It really should complain about missing credentials cache, but apparently
libzephyr tries again without auth in ZCancelSubscription even though the
server rejects unauthenticated ones. Meh.)
