### PR TITLE
Use "our" instead of "my" for zephyrStartup hook

### DIFF
--- a/perl/lib/BarnOwl/Zephyr.pm
+++ b/perl/lib/BarnOwl/Zephyr.pm
@@ -11,7 +11,7 @@ package BarnOwl::Zephyr;
 
 use BarnOwl::Hook;
 
-my $zephyrStartup = BarnOwl::Hook->new;
+our $zephyrStartup = BarnOwl::Hook->new;
 
 sub _zephyr_startup {
     $zephyrStartup->run;


### PR DESCRIPTION
All our other hooks seem to be defined using "our", and I don't seem to be able
to use the zephyrStartup hook without this change.
http://perldoc.perl.org/functions/our.html does claim the scoping should be the
same (though it also seems to suggest that only "our" gives a package variable
instead of something only in the current lexical scope...).
