### PR TITLE
add -c filsrv to reply-lockout

### DIFF
--- a/global.c
+++ b/global.c
@@ -855,7 +855,7 @@ void owl_global_setup_default_filters(owl_global *g)
     { "ping", "opcode ^ping$" },
     { "auto", "opcode ^auto$" },
     { "login", "not login ^none$" },
-    { "reply-lockout", "class ^mail$" },
+    { "reply-lockout", "class ^mail$ or class ^filsrv$" },
     { "out", "direction ^out$" },
     { "aim", "type ^aim$" },
     { "zephyr", "type ^zephyr$" },


### PR DESCRIPTION
We should fail fast on -c filsrv, which most people won't have permission to send to

geofft said:

> -c filsrv wasn't abandoned, although it's vaguely broken right now. Wanna file a bug to the effect of adding it to reply-lockout?
