### PR TITLE
Authors fixup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,11 +32,11 @@ The following people have provided patches or other contributions:
   Betsy Riley
   Robert Jacobs
 
-BarnOwl is based on code from Owl, which was originally primarly
+BarnOwl is based on code from Owl, which was originally primarily
 written by James Kretchmar.  Erik Nygren also made substantial
-contributions and improvemnts to the program.
+contributions and improvements to the program.
 
-The following people provided patches and other techincal support for
+The following people provided patches and other technical support for
 Owl:
 
   Stephen Gildea
@@ -49,7 +49,7 @@ Owl:
   David Glasser
   Mark Eichin
 
-Mark Eichin is also maintaining the debian package of Owl.
+Mark Eichin is also maintaining the Debian package of Owl.
 
 The following people helped with beta testing the earliest versions of
 Owl:


### PR DESCRIPTION
Fix spelling errors in AUTHORS (caught by ispell), and add more people to AUTHORS

I've added everyone from https://github.com/barnowl/barnowl/graphs/contributors whose name I knew (or whose name was listed on their profile page).  I did not manage to list austein, ecprice, or timhillgit.  I guessed that rileyb is rileyb@mit.edu, and used MIT people search to guess "Amy Riley".
