### PR TITLE
new_variable_* reinit

### DIFF
--- a/t/variable.t
+++ b/t/variable.t
@@ -16,6 +16,8 @@ BarnOwl::set("-q", "intvar", "string");
 is(BarnOwl::getvar("intvar"), "24", "intvar set bogus");
 BarnOwl::unset("-q", "intvar");
 is(BarnOwl::getvar("intvar"), "24", "intvar unset bogus");
+BarnOwl::new_variable_int("intvar", { default => 7 });
+isnt(BarnOwl::getvar("intvar"), "7", "intvar reinit shouldn't override preexisting value");
 
 BarnOwl::new_variable_bool("boolvar", { default => 1 });
 is(BarnOwl::getvar("boolvar"), "on", "boolvar default");
@@ -27,6 +29,8 @@ BarnOwl::set("-q", "boolvar");
 is(BarnOwl::getvar("boolvar"), "on", "boolvar set");
 BarnOwl::unset("-q", "boolvar");
 is(BarnOwl::getvar("boolvar"), "off", "boolvar unset");
+BarnOwl::new_variable_bool("boolvar", { default => 1 });
+isnt(BarnOwl::getvar("boolvar"), "on", "boolvar reinit shouldn't override preexisting value");
 
 BarnOwl::new_variable_string("strvar", { default => "monkey" });
 is(BarnOwl::getvar("strvar"), "monkey", "strvar default");
@@ -36,6 +40,8 @@ BarnOwl::set("-q", "strvar");
 is(BarnOwl::getvar("strvar"), "cuttlefish", "strvar set bogus");
 BarnOwl::unset("-q", "strvar");
 is(BarnOwl::getvar("strvar"), "cuttlefish", "strvar unset bogus");
+BarnOwl::new_variable_string("strvar", { default => "monkey" });
+isnt(BarnOwl::getvar("strvar"), "monkey", "strvar reinit overrode set value");
 
 BarnOwl::new_variable_enum("enumvar", { validsettings => [qw/foo bar baz/], default => "bar" });
 is(BarnOwl::getvar("enumvar"), "bar", "enumvar default");
@@ -45,6 +51,8 @@ BarnOwl::set("-q", "enumvar", "bogus");
 is(BarnOwl::getvar("enumvar"), "baz", "boolvar set bogus");
 BarnOwl::unset("-q", "enumvar");
 is(BarnOwl::getvar("enumvar"), "baz", "enumvar unset bogus");
+BarnOwl::new_variable_enum("enumvar", { validsettings => [qw/foo bar baz/], default => "bar" });
+isnt(BarnOwl::getvar("enumvar"), "bar", "enumvar reinit overrode set value");
 
 BarnOwl::new_variable_int("intvar2");
 is(BarnOwl::getvar("intvar2"), "0", "intvar default default");
@@ -77,6 +85,18 @@ BarnOwl::set("-q", "fullvar", "bogus");
 is(BarnOwl::getvar("fullvar"), "value is off", "fullvar set bogus");
 $value = "something really long";
 is(BarnOwl::getvar("fullvar"), "value is something really long", "fullvar set out-of-band");
+# Kinda verbose, but better to test all forms
+my $value = "foo";
+BarnOwl::new_variable_full("fullvar", {
+    validsettings => '<short-words>',
+    get_tostring => sub { "value is " . $value },
+    set_fromstring => sub {
+	die "Too long" unless $_[0] =~ /^...?$/;
+	$value = $_[0];
+    },
+    takes_on_off => 1
+});
+isnt(BarnOwl::getvar("fullvar"), "value is foo", "fullvar reinit overrode set value");
 
 1;
 


### PR DESCRIPTION
perlvariables accidently changed the way new_variable_\* works (and overrides any currently set variable). This commit adds tests to detect that.
