### PR TITLE
More release notes

### DIFF
--- a/doc/releasing-barnowl.txt
+++ b/doc/releasing-barnowl.txt
@@ -38,6 +38,7 @@
 
 * DOING THE ACTUAL RELEASE
   - [ ] Update the changelog and configure.ac for barnowl 1.N
+  - [ ] Copy the changelog changes to the master branch
   - [ ] run ./scripts/do-release
   - [ ] Do the locker build
   - [ ] Push the release tag


### PR DESCRIPTION
The release notes instructions now mention updating launchpad, tagging barnowl-1.(N+1)dev, and copying ChangeLog updates to master.
