### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: perl
+compiler:
+  - clang
+  - gcc
+perl:
+  - "5.10"
+  - "5.12"
+  - "5.14"
+  - "5.16"
+  - "5.18"
+  - "5.19"
+install:
+  - sudo apt-get update -q
+# we actually want debhelper >= 7, libperl-dev >= 5.10.1-8, libzephyr-dev >= 3.0~beta
+  - sudo apt-get install -q autoconf autotools-dev debhelper dh-autoreconf libglib2.0-dev libkrb5-dev libncurses5-dev libncursesw5-dev libssl-dev libzephyr-dev pkg-config zip
+# perl things
+# In lp:~barnowl/barnowl/packaging, we use apt-get.  Here, we use cpanm.
+#  - sudo apt-get install libanyevent-perl libclass-accessor-perl libextutils-depends-perl libglib-perl libmodule-install-perl libnet-twitter-lite-perl libpar-perl libperl-dev
+  - cpanm AnyEvent Class::Accessor ExtUtils::Depends Glib Module::Install Net::Twitter::Lite PAR
+script: "./autogen.sh && ./configure && make distcheck"


### PR DESCRIPTION
This adds support for the free Travis Continuous Integration service.  It also defined `_XOPEN_SOURCE_EXTENDED`, because that's apparently needed.  The comment on `_XOPEN_SOURCE_EXTENDED` comes mostly from davidben.   Someone who has admin bits on the github barnowl repo will need to enable Travis CI at https://travis-ci.org/profile/barnowl.
