### PR TITLE
Unbreak connecting to Google / Facebook with XMPP

### DIFF
--- a/perl/modules/Jabber/lib/BarnOwl/Module/Jabber.pm
+++ b/perl/modules/Jabber/lib/BarnOwl/Module/Jabber.pm
@@ -1312,7 +1312,7 @@ sub getServerFromJID {
     if ($packet)    # Got srv record.
     {
         my @answer = $packet->answer;
-        return $answer[0]{target}, $answer[0]{port};
+        return $answer[0]->target, $answer[0]->port if @answer;
     }
 
     return $jid->GetServer(), 5222;


### PR DESCRIPTION
Fix BarnOwl::Module::Jabber::getServerFromJID to use Net::DNS::RR::SRV methods instead of hash access (which seem to no longer work).  This unbreaks connecting via Jabber to Google or Facebook.
