### PR TITLE
scripts/do-release: Build distribution with ‘make distcheck’

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,8 @@ if ENABLE_ZCRYPT
 bin_PROGRAMS += zcrypt
 endif
 
-zcrypt_SOURCES = zcrypt.c filterproc.c version.c
+zcrypt_SOURCES = zcrypt.c filterproc.c
+nodist_zcrypt_SOURCES = version.c
 
 check_PROGRAMS = bin/tester
 dist_check_DATA = t

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,12 +1,16 @@
 ACLOCAL_AMFLAGS = -I m4
 
 GIT_DESCRIPTION := $(if $(wildcard $(srcdir)/.git),$(shell cd $(srcdir) && git describe --match='barnowl-*' HEAD 2>/dev/null))
-VERSION = $(if $(GIT_DESCRIPTION),$(GIT_DESCRIPTION:barnowl-%=%),@VERSION@)
--include BUILD_VERSION.mk
+VERSION = $(if $(GIT_DESCRIPTION),$(GIT_DESCRIPTION:barnowl-%=%),$(DIST_VERSION))
+DIST_VERSION = @VERSION@
+-include $(srcdir)/DIST_VERSION.mk BUILD_VERSION.mk
 
 FORCE:
 BUILD_VERSION.mk: $(if $(filter-out $(BUILD_VERSION),$(VERSION)),FORCE)
 	echo 'BUILD_VERSION = $(VERSION)' > $@
+dist-hook:: $(if $(filter-out @VERSION@,$(VERSION)),dist-hook-version)
+dist-hook-version:
+	echo 'DIST_VERSION = $(VERSION)' > $(distdir)/DIST_VERSION.mk
 
 bin_PROGRAMS = bin/barnowl
 if ENABLE_ZCRYPT
@@ -104,6 +108,7 @@ check-syntax: proto
 	$(COMPILE) -Wall -Wextra -pedantic -fsyntax-only $(CHK_SOURCES)
 
 CLEANFILES = $(BUILT_SOURCES) $(GEN_C) $(noinst_SCRIPTS) $(check_SCRIPTS) BUILD_VERSION.mk
+MAINTAINERCLEANFILES = DIST_VERSION.mk
 EXTRA_DIST = \
     autogen.sh \
     barnowl-wrapper.in \

--- a/scripts/dist-ignore
+++ b/scripts/dist-ignore
@@ -1,0 +1,13 @@
+	\(.*/\)\?\.gitignore
+	\.mailmap
+	\.travis\.yml
+DIST_VERSION.mk
+\(.*/\)\?Makefile\.in
+aclocal\.m4
+compile
+config\.h\.in
+configure
+depcomp
+install-sh
+missing
+test-driver

--- a/scripts/do-release
+++ b/scripts/do-release
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/bash
+set -eu
 
 die() {
     echo "$@" >&2
@@ -54,6 +55,21 @@ if [ -n "$(git rev-list $head..origin/$head)" ]; then
     die "$head is not up to date. Aborting."
 fi
 
+[ -e Makefile.in ] || autoreconf -fvi
+[ -e config.status ] || ./configure
+make -j4 distcheck VERSION="$VERS"
+
+echo 'Checking distributed files against Git:'
+if comm -3 <(tar -tzf "$TAG.tar.gz" | grep -v '/$' | sed "s%^$TAG/%%" | sort) \
+    <(git ls-files | sort) | grep -vxf scripts/dist-ignore; then
+    echo
+    echo 'Error: Please fix Makefile.am and/or scripts/dist-ignore.'
+    exit 1
+fi
+echo 'ok'
+
+mv "$TAG.tar.gz" "$TGZ.tgz"
+
 if ! [ "$no_tag" ]; then
     if git cat-file -t "$TAG" > /dev/null 2>&1; then
         die "Error: Object $TAG already exists."
@@ -64,31 +80,7 @@ else
     TAG=HEAD
 fi
 
-exittrap() { :; }
-for sig in 1 2 13 15; do trap "exit $(($sig + 128))" $sig; done
-trap 'exittrap' EXIT
-
-TMPDIR=$(mktemp -d /tmp/barnowl.XXXXXX)
-
-exittrap() { rm -rf "$TMPDIR"; }
-
-git archive --format=tar --prefix="$TGZ/" "$TAG" | tar -x -C "$TMPDIR"
-
-CODIR=$(pwd)
-cd "$TMPDIR/$TGZ"
-[ "$git" ] && perl -i -pe 's{^(AC_INIT\(\[[^\]]+\],\s*)\[([^\]]+)\]}{${1}['$VERS']}' configure.ac
-autoreconf -fvi
-rm -r autom4te.cache/
-cd "$TMPDIR"
-tar czvf "$TGZ.tgz" "$TGZ"
-cd "$CODIR"
-
-mv "$TMPDIR/$TGZ.tgz" .
-rm -rf "$TMPDIR"
-
-exittrap() { :; }
-
-echo "Created release tarball for BarnOwl $VERS in $(pwd)"
+echo "Created release tarball for BarnOwl $VERS at $(pwd)/$TGZ.tgz"
 echo "Remember to bump OWL_VERSION_STRING for future development."
 
 COMMIT=$(git rev-parse "$TAG")


### PR DESCRIPTION
I think we should start generating release tarballs with `make distcheck` for 1.10. Here’s an implementation.