### PR TITLE
Use the GLib slice allocator for fixed-size objects

### DIFF
--- a/aim.c
+++ b/aim.c
@@ -1048,7 +1048,7 @@ static int faimtest_parse_incoming_im_chan1(aim_session_t *sess, aim_conn_t *con
   stripmsg=owl_text_htmlstrip(realmsg);
   wrapmsg=owl_text_wordwrap(stripmsg, 70);
   nz_screenname=owl_aim_normalize_screenname(userinfo->sn);
-  m=g_new(owl_message, 1);
+  m=g_slice_new(owl_message);
   owl_message_create_aim(m,
 			 nz_screenname,
 			 owl_global_get_aim_screenname(&g),

--- a/buddy.c
+++ b/buddy.c
@@ -71,5 +71,5 @@ void owl_buddy_cleanup(owl_buddy *b)
 void owl_buddy_delete(owl_buddy *b)
 {
   owl_buddy_cleanup(b);
-  g_free(b);
+  g_slice_free(owl_buddy, b);
 }

--- a/buddylist.c
+++ b/buddylist.c
@@ -10,7 +10,7 @@ void owl_buddylist_init(owl_buddylist *bl)
 void owl_buddylist_add_aim_buddy(owl_buddylist *bl, const char *screenname)
 {
   owl_buddy *b;
-  b=g_new(owl_buddy, 1);
+  b=g_slice_new(owl_buddy);
   
   owl_buddy_create(b, OWL_PROTOCOL_AIM, screenname);
   g_ptr_array_add(bl->buddies, b);
@@ -49,7 +49,7 @@ void owl_buddylist_oncoming(owl_buddylist *bl, const char *screenname)
     if (owl_global_is_ignore_aimlogin(&g)) return;
 
     /* if not, create the login message */
-    m=g_new(owl_message, 1);
+    m=g_slice_new(owl_message);
     owl_message_create_aim(m,
 			   screenname,
 			   owl_global_get_aim_screenname(&g),
@@ -68,7 +68,7 @@ void owl_buddylist_offgoing(owl_buddylist *bl, const char *screenname)
   owl_message *m;
 
   if (owl_buddylist_is_aim_buddy_loggedin(bl, screenname)) {
-    m=g_new(owl_message, 1);
+    m=g_slice_new(owl_message);
     owl_message_create_aim(m,
 			   screenname,
 			   owl_global_get_aim_screenname(&g),

--- a/cmd.c
+++ b/cmd.c
@@ -34,16 +34,16 @@ const owl_cmd *owl_cmddict_find(const owl_cmddict *d, const char *name) {
 /* creates a new command alias */
 void owl_cmddict_add_alias(owl_cmddict *cd, const char *alias_from, const char *alias_to) {
   owl_cmd *cmd;
-  cmd = g_new(owl_cmd, 1);
+  cmd = g_slice_new(owl_cmd);
   owl_cmd_create_alias(cmd, alias_from, alias_to);
   owl_perlconfig_new_command(cmd->name);
   owl_dict_insert_element(cd, cmd->name, cmd, (void (*)(void *))owl_cmd_delete);
 }
 
 int owl_cmddict_add_cmd(owl_cmddict *cd, const owl_cmd * cmd) {
-  owl_cmd * newcmd = g_new(owl_cmd, 1);
+  owl_cmd * newcmd = g_slice_new(owl_cmd);
   if(owl_cmd_create_from_template(newcmd, cmd) < 0) {
-    g_free(newcmd);
+    g_slice_free(owl_cmd, newcmd);
     return -1;
   }
   owl_perlconfig_new_command(cmd->name);
@@ -140,7 +140,7 @@ void owl_cmd_cleanup(owl_cmd *cmd)
 void owl_cmd_delete(owl_cmd *cmd)
 {
   owl_cmd_cleanup(cmd);
-  g_free(cmd);
+  g_slice_free(owl_cmd, cmd);
 }
 
 int owl_cmd_is_context_valid(const owl_cmd *cmd, const owl_context *ctx) { 

--- a/context.c
+++ b/context.c
@@ -9,7 +9,7 @@ CALLER_OWN owl_context *owl_context_new(int mode, void *data, const char *keymap
   owl_context *c;
   if (!(mode & OWL_CTX_MODE_BITS))
     mode |= OWL_CTX_INTERACTIVE;
-  c = g_new0(owl_context, 1);
+  c = g_slice_new0(owl_context);
   c->mode = mode;
   c->data = data;
   c->cursor = cursor ? g_object_ref(cursor) : NULL;
@@ -70,5 +70,5 @@ void owl_context_delete(owl_context *ctx)
   g_free(ctx->keymap);
   if (ctx->delete_cb)
     ctx->delete_cb(ctx);
-  g_free(ctx);
+  g_slice_free(owl_context, ctx);
 }

--- a/editwin.c
+++ b/editwin.c
@@ -67,7 +67,7 @@ static void oe_window_resized(owl_window *w, owl_editwin *e);
 
 static CALLER_OWN owl_editwin *owl_editwin_allocate(void)
 {
-  owl_editwin *e = g_new0(owl_editwin, 1);
+  owl_editwin *e = g_slice_new0(owl_editwin);
   e->refcount = 1;
   return e;
 }
@@ -86,7 +86,7 @@ static void _owl_editwin_delete(owl_editwin *e)
   }
   oe_destroy_cbdata(e);
 
-  g_free(e);
+  g_slice_free(owl_editwin, e);
 }
 
 static inline void oe_set_index(owl_editwin *e, int index)
@@ -372,7 +372,7 @@ static void oe_restore_mark_only(owl_editwin *e, oe_excursion *x)
 /* External interface to oe_save_excursion */
 owl_editwin_excursion *owl_editwin_begin_excursion(owl_editwin *e)
 {
-  owl_editwin_excursion *x = g_new(owl_editwin_excursion, 1);
+  owl_editwin_excursion *x = g_slice_new(owl_editwin_excursion);
   oe_save_excursion(e, x);
   return x;
 }
@@ -380,7 +380,7 @@ owl_editwin_excursion *owl_editwin_begin_excursion(owl_editwin *e)
 void owl_editwin_end_excursion(owl_editwin *e, owl_editwin_excursion *x)
 {
   oe_restore_excursion(e, x);
-  g_free(x);
+  g_slice_free(owl_editwin_excursion, x);
 }
 
 static inline const char *oe_next_point(owl_editwin *e, const char *p)

--- a/filter.c
+++ b/filter.c
@@ -17,7 +17,7 @@ owl_filter *owl_filter_new(const char *name, int argc, const char *const *argv)
 {
   owl_filter *f;
 
-  f = g_new(owl_filter, 1);
+  f = g_slice_new(owl_filter);
 
   f->name=g_strdup(name);
   f->fgcolor=OWL_COLOR_DEFAULT;
@@ -68,7 +68,7 @@ static owl_filterelement * owl_filter_parse_primitive_expression(int argc, const
 
   if(!argc) return NULL;
 
-  fe = g_new(owl_filterelement, 1);
+  fe = g_slice_new(owl_filterelement);
   owl_filterelement_create(fe);
 
   if(!strcasecmp(argv[i], "(")) {
@@ -113,7 +113,7 @@ static owl_filterelement * owl_filter_parse_primitive_expression(int argc, const
   return fe;
 err:
   owl_filterelement_cleanup(fe);
-  g_free(fe);
+  g_slice_free(owl_filterelement, fe);
   return NULL;
 }
 
@@ -131,7 +131,7 @@ owl_filterelement * owl_filter_parse_expression(int argc, const char *const *arg
        strcasecmp(argv[i], "or")) break;
     op2 = owl_filter_parse_primitive_expression(argc-i-1, argv+i+1, &skip);
     if(!op2) goto err;
-    tmp = g_new(owl_filterelement, 1);
+    tmp = g_slice_new(owl_filterelement);
     if(!strcasecmp(argv[i], "and")) {
       owl_filterelement_create_and(tmp, op1, op2);
     } else {
@@ -151,7 +151,7 @@ owl_filterelement * owl_filter_parse_expression(int argc, const char *const *arg
 err:
   if(op1) {
     owl_filterelement_cleanup(op1);
-    g_free(op1);
+    g_slice_free(owl_filterelement, op1);
   }
   return NULL;
 }
@@ -261,9 +261,9 @@ void owl_filter_delete(owl_filter *f)
     return;
   if (f->root) {
     owl_filterelement_cleanup(f->root);
-    g_free(f->root);
+    g_slice_free(owl_filterelement, f->root);
   }
   if (f->name)
     g_free(f->name);
-  g_free(f);
+  g_slice_free(owl_filter, f);
 }

--- a/filterelement.c
+++ b/filterelement.c
@@ -327,11 +327,11 @@ void owl_filterelement_cleanup(owl_filterelement *fe)
   if (fe->field) g_free(fe->field);
   if (fe->left) {
     owl_filterelement_cleanup(fe->left);
-    g_free(fe->left);
+    g_slice_free(owl_filterelement, fe->left);
   }
   if (fe->right) {
     owl_filterelement_cleanup(fe->right);
-    g_free(fe->right);
+    g_slice_free(owl_filterelement, fe->right);
   }
   owl_regex_cleanup(&(fe->re));
 }

--- a/functions.c
+++ b/functions.c
@@ -195,7 +195,7 @@ void owl_function_adminmsg(const char *header, const char *body)
 {
   owl_message *m;
 
-  m=g_new(owl_message, 1);
+  m=g_slice_new(owl_message);
   owl_message_create_admin(m, header, body);
   
   /* add it to the global list and current view */
@@ -217,7 +217,7 @@ void owl_function_add_outgoing_zephyrs(const owl_zwrite *z)
 {
   if (z->cc && owl_zwrite_is_personal(z)) {
     /* create the message */
-    owl_message *m = g_new(owl_message, 1);
+    owl_message *m = g_slice_new(owl_message);
     owl_message_create_from_zwrite(m, z, owl_zwrite_get_message(z), 0);
 
     owl_global_messagequeue_addmsg(&g, m);
@@ -230,7 +230,7 @@ void owl_function_add_outgoing_zephyrs(const owl_zwrite *z)
         continue;
 
       /* create the message */
-      m = g_new(owl_message, 1);
+      m = g_slice_new(owl_message);
       owl_message_create_from_zwrite(m, z, owl_zwrite_get_message(z), i);
 
       owl_global_messagequeue_addmsg(&g, m);
@@ -250,7 +250,7 @@ CALLER_OWN owl_message *owl_function_make_outgoing_aim(const char *body, const c
   /* error if we're not logged into aim */
   if (!owl_global_is_aimloggedin(&g)) return(NULL);
   
-  m=g_new(owl_message, 1);
+  m=g_slice_new(owl_message);
   owl_message_create_aim(m,
 			 owl_global_get_aim_screenname(&g),
 			 to,
@@ -269,7 +269,7 @@ CALLER_OWN owl_message *owl_function_make_outgoing_loopback(const char *body)
   owl_message *m;
 
   /* create the message */
-  m=g_new(owl_message, 1);
+  m=g_slice_new(owl_message);
   owl_message_create_loopback(m, body);
   owl_message_set_direction_out(m);
 
@@ -515,7 +515,7 @@ void owl_function_loopwrite(const char *msg)
 
   /* create a message and put it on the message queue.  This simulates
    * an incoming message */
-  min=g_new(owl_message, 1);
+  min=g_slice_new(owl_message);
   mout=owl_function_make_outgoing_loopback(msg);
 
   if (owl_global_is_displayoutgoing(&g)) {
@@ -3481,7 +3481,7 @@ void owl_function_zephyr_buddy_check(int notify)
   zaldptr = g_list_first(*zaldlist);
   while (zaldptr) {
     ZFreeALD(zaldptr->data);
-    g_free(zaldptr->data);
+    g_slice_free(ZAsyncLocateData_t, zaldptr->data);
     zaldptr = g_list_next(zaldptr);
   }
   g_list_free(*zaldlist);
@@ -3491,11 +3491,11 @@ void owl_function_zephyr_buddy_check(int notify)
   if (anyone != NULL) {
     for (i = 0; i < anyone->len; i++) {
       user = anyone->pdata[i];
-      zald = g_new(ZAsyncLocateData_t, 1);
+      zald = g_slice_new(ZAsyncLocateData_t);
       if (ZRequestLocations(zstr(user), zald, UNACKED, ZAUTH) == ZERR_NONE) {
         *zaldlist = g_list_append(*zaldlist, zald);
       } else {
-        g_free(zald);
+        g_slice_free(ZAsyncLocateData_t, zald);
       }
     }
     owl_ptr_array_free(anyone, g_free);

--- a/global.c
+++ b/global.c
@@ -552,11 +552,11 @@ static void owl_global_delete_filter_ent(void *data)
   owl_global_filter_ent *e = data;
   e->g->filterlist = g_list_remove(e->g->filterlist, e->f);
   owl_filter_delete(e->f);
-  g_free(e);
+  g_slice_free(owl_global_filter_ent, e);
 }
 
 void owl_global_add_filter(owl_global *g, owl_filter *f) {
-  owl_global_filter_ent *e = g_new(owl_global_filter_ent, 1);
+  owl_global_filter_ent *e = g_slice_new(owl_global_filter_ent);
   e->g = g;
   e->f = f;
 

--- a/keybinding.c
+++ b/keybinding.c
@@ -13,11 +13,11 @@ static int owl_keybinding_make_keys(owl_keybinding *kb, const char *keyseq);
 /* sets up a new keybinding for a command */
 CALLER_OWN owl_keybinding *owl_keybinding_new(const char *keyseq, const char *command, void (*function_fn)(void), const char *desc)
 {
-  owl_keybinding *kb = g_new(owl_keybinding, 1);
+  owl_keybinding *kb = g_slice_new(owl_keybinding);
 
   owl_function_debugmsg("owl_keybinding_init: creating binding for <%s> with desc: <%s>", keyseq, desc);
   if (command && function_fn) {
-    g_free(kb);
+    g_slice_free(owl_keybinding, kb);
     return NULL;
   } else if (command && !function_fn) {
     kb->type = OWL_KEYBINDING_COMMAND;
@@ -28,7 +28,7 @@ CALLER_OWN owl_keybinding *owl_keybinding_new(const char *keyseq, const char *co
   }
 
   if (owl_keybinding_make_keys(kb, keyseq) != 0) {
-    g_free(kb);
+    g_slice_free(owl_keybinding, kb);
     return NULL;
   }
 
@@ -69,7 +69,7 @@ void owl_keybinding_delete(owl_keybinding *kb)
   g_free(kb->keys);
   g_free(kb->desc);
   g_free(kb->command);
-  g_free(kb);
+  g_slice_free(owl_keybinding, kb);
 }
 
 /* executes a keybinding */

--- a/keymap.c
+++ b/keymap.c
@@ -188,7 +188,7 @@ void owl_keyhandler_add_keymap(owl_keyhandler *kh, owl_keymap *km)
 owl_keymap *owl_keyhandler_create_and_add_keymap(owl_keyhandler *kh, const char *name, const char *desc, void (*default_fn)(owl_input), void (*prealways_fn)(owl_input), void (*postalways_fn)(owl_input))
 {
   owl_keymap *km;
-  km = g_new(owl_keymap, 1);
+  km = g_slice_new(owl_keymap);
   owl_keymap_init(km, name, desc, default_fn, prealways_fn, postalways_fn);
   owl_keyhandler_add_keymap(kh, km);
   return km;

--- a/logging.c
+++ b/logging.c
@@ -176,14 +176,14 @@ static void owl_log_entry_free(void *data)
   if (msg) {
     g_free(msg->message);
     g_free(msg->filename);
-    g_free(msg);
+    g_slice_free(owl_log_entry, msg);
   }
 }
 
 void owl_log_enqueue_message(const char *buffer, const char *filename)
 {
   owl_log_entry *log_msg = NULL; 
-  log_msg = g_new(owl_log_entry,1);
+  log_msg = g_slice_new(owl_log_entry);
   log_msg->message = g_strdup(buffer);
   log_msg->filename = g_strdup(filename);
   owl_select_post_task(owl_log_write_entry, log_msg, 
@@ -265,7 +265,7 @@ void owl_log_outgoing_zephyr_error(const owl_zwrite *zw, const char *text)
   /* create a present message so we can pass it to
    * owl_log_shouldlog_message(void)
    */
-  m = g_new(owl_message, 1);
+  m = g_slice_new(owl_message);
   /* recip_index = 0 because there can only be one recipient anyway */
   owl_message_create_from_zwrite(m, zw, text, 0);
   if (!owl_log_shouldlog_message(m)) {

--- a/mainwin.c
+++ b/mainwin.c
@@ -5,7 +5,7 @@ static void owl_mainwin_resized(owl_window *w, void *user_data);
 
 CALLER_OWN owl_mainwin *owl_mainwin_new(owl_window *window)
 {
-  owl_mainwin *mw = g_new(owl_mainwin, 1);
+  owl_mainwin *mw = g_slice_new(owl_mainwin);
   mw->curtruncated=0;
   mw->lastdisplayed=-1;
   mw->window = g_object_ref(window);

--- a/message.c
+++ b/message.c
@@ -69,7 +69,7 @@ void owl_message_set_attribute(owl_message *m, const char *attrname, const char 
   }
 
   if(pair ==  NULL) {
-    pair = g_new(owl_pair, 1);
+    pair = g_slice_new(owl_pair);
     owl_pair_create(pair, attrname, NULL);
     g_ptr_array_add(m->attributes, pair);
   }
@@ -1018,7 +1018,7 @@ void owl_message_cleanup(owl_message *m)
   for (i = 0; i < m->attributes->len; i++) {
     p = m->attributes->pdata[i];
     g_free(owl_pair_get_value(p));
-    g_free(p);
+    g_slice_free(owl_pair, p);
   }
 
   g_ptr_array_free(m->attributes, true);
@@ -1029,5 +1029,5 @@ void owl_message_cleanup(owl_message *m)
 void owl_message_delete(owl_message *m)
 {
   owl_message_cleanup(m);
-  g_free(m);
+  g_slice_free(owl_message, m);
 }

--- a/messagelist.c
+++ b/messagelist.c
@@ -2,7 +2,7 @@
 
 CALLER_OWN owl_messagelist *owl_messagelist_new(void)
 {
-  owl_messagelist *ml = g_new(owl_messagelist, 1);
+  owl_messagelist *ml = g_slice_new(owl_messagelist);
   ml->list = g_ptr_array_new();
   return ml;
 }
@@ -12,7 +12,7 @@ void owl_messagelist_delete(owl_messagelist *ml, bool free_messages)
   if (free_messages)
     g_ptr_array_foreach(ml->list, (GFunc)owl_message_delete, NULL);
   g_ptr_array_free(ml->list, true);
-  g_free(ml);
+  g_slice_free(owl_messagelist, ml);
 }
 
 int owl_messagelist_get_size(const owl_messagelist *ml)

--- a/perlconfig.c
+++ b/perlconfig.c
@@ -187,7 +187,7 @@ CALLER_OWN owl_message *owl_perlconfig_hashref2message(SV *msg)
 
   hash = (HV*)SvRV(msg);
 
-  m = g_new(owl_message, 1);
+  m = g_slice_new(owl_message);
   owl_message_init(m);
 
   hv_iterinit(hash);

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -231,7 +231,7 @@ create_style(name, object)
 		owl_style *s;
      CODE:
 	{
-		s = g_new(owl_style, 1);
+		s = g_slice_new(owl_style);
 		owl_style_create_perl(s, name, newSVsv(object));
 		owl_global_add_style(&g, s);
 	}

--- a/popexec.c
+++ b/popexec.c
@@ -22,7 +22,7 @@ owl_popexec *owl_popexec_new(const char *command)
     return NULL;
   }
 
-  pe = g_new(owl_popexec, 1);
+  pe = g_slice_new(owl_popexec);
   pe->winactive=0;
   pe->pid=0;
   pe->refcount=0;
@@ -178,6 +178,6 @@ void owl_popexec_unref(owl_popexec *pe)
   pe->refcount--;
   if (pe->refcount<=0) {
     owl_function_debugmsg("doing free of %p", pe);
-    g_free(pe);
+    g_slice_free(owl_popexec, pe);
   }
 }

--- a/popwin.c
+++ b/popwin.c
@@ -2,7 +2,7 @@
 
 CALLER_OWN owl_popwin *owl_popwin_new(void)
 {
-  owl_popwin *pw = g_new0(owl_popwin, 1);
+  owl_popwin *pw = g_slice_new0(owl_popwin);
 
   pw->border = owl_window_new(NULL);
   pw->content = owl_window_new(pw->border);
@@ -91,7 +91,7 @@ void owl_popwin_delete(owl_popwin *pw)
   g_object_unref(pw->border);
   g_object_unref(pw->content);
 
-  g_free(pw);
+  g_slice_free(owl_popwin, pw);
 }
 
 int owl_popwin_is_active(const owl_popwin *pw)

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+export G_SLICE=debug-blocks
 exec env HARNESS_PERL=./tester prove --failures "${srcdir:=$(dirname "$0")}/t/"

--- a/select.c
+++ b/select.c
@@ -40,13 +40,13 @@ static void _destroy_task(void *data)
   owl_task *t = data;
   if (t->destroy_cbdata)
     t->destroy_cbdata(t->cbdata);
-  g_free(t);
+  g_slice_free(owl_task, t);
 }
 
 void owl_select_post_task(void (*cb)(void*), void *cbdata, void (*destroy_cbdata)(void*), GMainContext *context)
 {
   GSource *source = g_idle_source_new();
-  owl_task *t = g_new0(owl_task, 1);
+  owl_task *t = g_slice_new0(owl_task);
   t->cb = cb;
   t->cbdata = cbdata;
   t->destroy_cbdata = destroy_cbdata;

--- a/style.c
+++ b/style.c
@@ -102,5 +102,5 @@ void owl_style_cleanup(owl_style *s)
 void owl_style_delete(owl_style *s)
 {
   owl_style_cleanup(s);
-  g_free(s);
+  g_slice_free(owl_style, s);
 }

--- a/variable.c
+++ b/variable.c
@@ -626,7 +626,7 @@ void owl_variable_dict_add_variable(owl_vardict * vardict,
 }
 
 static owl_variable *owl_variable_newvar(int type, const char *name, const char *summary, const char *description, const char *validsettings) {
-  owl_variable *var = g_new0(owl_variable, 1);
+  owl_variable *var = g_slice_new0(owl_variable);
   var->type = type;
   var->name = g_strdup(name);
   var->summary = g_strdup(summary);
@@ -792,7 +792,7 @@ void owl_variable_delete(owl_variable *v)
   g_closure_unref(v->get_tostring_fn);
   g_closure_unref(v->set_fromstring_fn);
 
-  g_free(v);
+  g_slice_free(owl_variable, v);
 }
 
 

--- a/viewwin.c
+++ b/viewwin.c
@@ -12,7 +12,7 @@ static void owl_viewwin_set_window(owl_viewwin *v, owl_window *w);
  */
 CALLER_OWN owl_viewwin *owl_viewwin_new_text(owl_window *win, const char *text)
 {
-  owl_viewwin *v = g_new0(owl_viewwin, 1);
+  owl_viewwin *v = g_slice_new0(owl_viewwin);
   owl_fmtext_init_null(&(v->fmtext));
   if (text) {
     owl_fmtext_append_normal(&(v->fmtext), text);
@@ -35,7 +35,7 @@ CALLER_OWN owl_viewwin *owl_viewwin_new_text(owl_window *win, const char *text)
 CALLER_OWN owl_viewwin *owl_viewwin_new_fmtext(owl_window *win, const owl_fmtext *fmtext)
 {
   char *text;
-  owl_viewwin *v = g_new0(owl_viewwin, 1);
+  owl_viewwin *v = g_slice_new0(owl_viewwin);
 
   owl_fmtext_copy(&(v->fmtext), fmtext);
   text = owl_fmtext_print_plain(fmtext);
@@ -423,5 +423,5 @@ void owl_viewwin_delete(owl_viewwin *v)
   g_object_unref(v->content);
   g_object_unref(v->status);
   owl_fmtext_cleanup(&(v->fmtext));
-  g_free(v);
+  g_slice_free(owl_viewwin, v);
 }

--- a/zephyr.c
+++ b/zephyr.c
@@ -124,7 +124,7 @@ gboolean owl_zephyr_finish_initialization(GIOChannel *source, GIOCondition condi
     owl_function_debugmsg("Loading %d deferred subs.", subs->nsubs);
     owl_zephyr_loadsubs_helper(subs->subs, subs->nsubs);
     deferred_subs = g_list_delete_link(deferred_subs, deferred_subs);
-    g_free(subs);
+    g_slice_free(owl_sub_list, subs);
   }
 
   /* zlog in if we need to */
@@ -260,7 +260,7 @@ int owl_zephyr_loadsubs_helper(ZSubscription_t subs[], int count)
 
     g_free(subs);
   } else {
-    owl_sub_list *s = g_new(owl_sub_list, 1);
+    owl_sub_list *s = g_slice_new(owl_sub_list);
     s->subs = subs;
     s->nsubs = count;
     deferred_subs = g_list_append(deferred_subs, s);
@@ -1412,7 +1412,7 @@ void owl_zephyr_process_pseudologin(ZNotice_t *n)
           ret = ZGetLocations(&location, &numlocs);
           if (ret == ZERR_NONE) {
             /* Send a PSEUDO LOGIN! */
-            m = g_new(owl_message, 1);
+            m = g_slice_new(owl_message);
             owl_message_create_pseudo_zlogin(m, 0, zald->user,
                                              location.host,
                                              location.time,
@@ -1425,7 +1425,7 @@ void owl_zephyr_process_pseudologin(ZNotice_t *n)
       } else if (numlocs == 0 && owl_zbuddylist_contains_user(zbl, zald->user)) {
         /* Send a PSEUDO LOGOUT! */
         if (notify) {
-          m = g_new(owl_message, 1);
+          m = g_slice_new(owl_message);
           owl_message_create_pseudo_zlogin(m, 1, zald->user, "", "", "");
           owl_global_messagequeue_addmsg(&g, m);
         }
@@ -1434,7 +1434,7 @@ void owl_zephyr_process_pseudologin(ZNotice_t *n)
       }
     }
     ZFreeALD(zald);
-    g_free(zald);
+    g_slice_free(ZAsyncLocateData_t, zald);
   }
 }
 #else
@@ -1501,7 +1501,7 @@ static int _owl_zephyr_process_events(void)
       }
 
       /* create the new message */
-      m=g_new(owl_message, 1);
+      m=g_slice_new(owl_message);
       owl_message_create_from_znotice(m, &notice);
 
       owl_global_messagequeue_addmsg(&g, m);

--- a/zwrite.c
+++ b/zwrite.c
@@ -2,9 +2,9 @@
 
 CALLER_OWN owl_zwrite *owl_zwrite_new_from_line(const char *line)
 {
-  owl_zwrite *z = g_new(owl_zwrite, 1);
+  owl_zwrite *z = g_slice_new(owl_zwrite);
   if (owl_zwrite_create_from_line(z, line) != 0) {
-    g_free(z);
+    g_slice_free(owl_zwrite, z);
     return NULL;
   }
   return z;
@@ -12,9 +12,9 @@ CALLER_OWN owl_zwrite *owl_zwrite_new_from_line(const char *line)
 
 CALLER_OWN owl_zwrite *owl_zwrite_new(int argc, const char *const *argv)
 {
-  owl_zwrite *z = g_new(owl_zwrite, 1);
+  owl_zwrite *z = g_slice_new(owl_zwrite);
   if (owl_zwrite_create(z, argc, argv) != 0) {
-    g_free(z);
+    g_slice_free(owl_zwrite, z);
     return NULL;
   }
   return z;
@@ -355,7 +355,7 @@ bool owl_zwrite_is_personal(const owl_zwrite *z)
 void owl_zwrite_delete(owl_zwrite *z)
 {
   owl_zwrite_cleanup(z);
-  g_free(z);
+  g_slice_free(owl_zwrite, z);
 }
 
 void owl_zwrite_cleanup(owl_zwrite *z)


### PR DESCRIPTION
The slice allocator, available since GLib 2.10, is more space-efficient than [g_]malloc.  Since BarnOwl is obviously at the leading edge of space-efficient technology, this seems like a natural fit.  Use it for every fixed-size object except owl_viewwin_search_data (which would need an extra destroy_cbdata function to g_slice_free it).
