### PR TITLE
HTML::Entities or HTML::HTML5::Entities, the modern replacement.

### DIFF
--- a/README
+++ b/README
@@ -54,7 +54,7 @@ Digest::SHA
 
 The Twitter module requires:
 
-HTML::Entities
+HTML::Entities (or HTML::HTML5::Entities)
 Net::Twitter::Lite
 
 The WordWrap module requires:


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
