### PR TITLE
Clean up ircnets on socketless disconnect

### DIFF
--- a/perl/modules/IRC/lib/BarnOwl/Module/IRC.pm
+++ b/perl/modules/IRC/lib/BarnOwl/Module/IRC.pm
@@ -562,6 +562,10 @@ sub cmd_disconnect {
                                "[" . $conn->alias . "] Reconnect cancelled");
         $conn->cancel_reconnect;
         delete $ircnets{$conn->alias};
+    } elsif (exists $ircnets{$conn->alias}) { # inconsistent state; no socket, but not yet deleted
+        BarnOwl::admin_message('IRC',
+                               "[" . $conn->alias . "] Attempt to disconnect from a socketless connection; deleting it");
+        delete $ircnets{$conn->alias};
     }
 }
 


### PR DESCRIPTION
This allows recovery from the state that BarnOwl gets into when (I
think) a disconnect message from the server is dropped, and BarnOwl
thinks it's connected, and the IRC server thinks it's not, and so you
can neither disconnect nor reconnect.