### PR TITLE
Update .travis.yml away from legacy infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-
 language: perl
+sudo: false
 compiler:
   - clang
   - gcc
@@ -10,12 +10,25 @@ perl:
   - "5.16"
   - "5.18"
   - "5.20"
+addons:
+  apt:
+    # we actually want debhelper >= 7, libperl-dev >= 5.10.1-8, libzephyr-dev >= 3.0~beta
+    packages:
+    - autoconf
+    - autotools-dev
+    - debhelper
+    - dh-autoreconf
+    - libglib2.0-dev
+    - libkrb5-dev
+    - libncurses5-dev
+    - libncursesw5-dev
+    - libssl-dev
+    - libzephyr-dev
+    - pkg-config
+    - zip
 install:
-  - sudo apt-get update -q
-# we actually want debhelper >= 7, libperl-dev >= 5.10.1-8, libzephyr-dev >= 3.0~beta
-  - sudo apt-get install -q autoconf autotools-dev debhelper dh-autoreconf libglib2.0-dev libkrb5-dev libncurses5-dev libncursesw5-dev libssl-dev libzephyr-dev pkg-config zip
 # perl things
 # In lp:~barnowl/barnowl/packaging, we use apt-get.  Here, we use cpanm.
 #  - sudo apt-get install libanyevent-perl libclass-accessor-perl libextutils-depends-perl libglib-perl libmodule-install-perl libnet-twitter-lite-perl libpar-perl libperl-dev
   - cpanm AnyEvent Class::Accessor ExtUtils::Depends Glib Module::Install Net::Twitter::Lite PAR
-script: "./autogen.sh && ./configure && make distcheck"
+script: ./autogen.sh && ./configure && make distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,8 @@ addons:
     - libzephyr-dev
     - pkg-config
     - zip
-install:
 # perl things
 # In lp:~barnowl/barnowl/packaging, we use apt-get.  Here, we use cpanm.
 #  - sudo apt-get install libanyevent-perl libclass-accessor-perl libextutils-depends-perl libglib-perl libmodule-install-perl libnet-twitter-lite-perl libpar-perl libperl-dev
-  - cpanm AnyEvent Class::Accessor ExtUtils::Depends Glib Module::Install Net::Twitter::Lite PAR
+# It's taken care of by the default install script
 script: ./autogen.sh && ./configure && make distcheck

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,7 @@
+requires 'AnyEvent';
+requires 'Class::Accessor';
+requires 'ExtUtils::Depends';
+requires 'Glib';
+requires 'Module::Install';
+requires 'Net::Twitter::Lite';
+requires 'PAR';

--- a/cpanfile
+++ b/cpanfile
@@ -5,3 +5,16 @@ requires 'Glib';
 requires 'Module::Install';
 requires 'Net::Twitter::Lite';
 requires 'PAR';
+
+# feature 'facebook', 'Facebook support' => sub {
+requires 'Any::Moose', '>= 0.13';
+requires 'AnyEvent::HTTP';
+requires 'DateTime', '>= 0.61';
+requires 'DateTime::Format::Strptime', '>= 1.4000';
+requires 'JSON', '>= 2.16';
+requires 'Lingua::EN::Keywords';
+requires 'MIME::Base64::URLSafe', '>= 0.01';
+requires 'Ouch', '>= 0.0400';
+requires 'URI', '>= 1.54';
+requires 'URI::Encode', '>= 0.02';
+# }


### PR DESCRIPTION
Following https://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade.

Also add a cpanfile for cpan dependencies so the default install script of `cpanm --quiet --installdeps --notest .` Just Works.