### PR TITLE
rewrite zephyr scribelike markup parsing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ The following people have provided patches or other contributions:
   DD Liu
   Betsy Riley
   Robert Jacobs
+  Google Inc.
 
 BarnOwl is based on code from Owl, which was originally primarily
 written by James Kretchmar.  Erik Nygren also made substantial

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,7 +55,7 @@ AM_CPPFLAGS = \
 
 CODELIST_SRCS=message.c mainwin.c popwin.c zephyr.c messagelist.c \
      commands.c global.c text.c fmtext.c editwin.c \
-     util.c logging.c \
+     util.c logging.c ztext.c \
      perlconfig.c keys.c functions.c zwrite.c viewwin.c help.c filter.c \
      regex.c history.c view.c dict.c variable.c filterelement.c pair.c \
      keypress.c keymap.c keybinding.c cmd.c context.c \

--- a/fmtext.c
+++ b/fmtext.c
@@ -556,14 +556,16 @@ static void owl_fmtext_append_ztext_tree(owl_fmtext *f, ztext_env *tree, char at
   bool handled = false;
   const struct {
     const char *tag;
-    const char mask;
+    enum {SET,  MASK} mode;
+    const char val;
   } TAGS[] = {
-    {"", 0},
-    {"@", 0},
-    {"@bold", OWL_FMTEXT_ATTR_BOLD},
-    {"@b", OWL_FMTEXT_ATTR_BOLD},
-    {"@italic", OWL_FMTEXT_ATTR_UNDERLINE},
-    {"@i", OWL_FMTEXT_ATTR_UNDERLINE},
+    {"", MASK, 0},
+    {"@", MASK, 0},
+    {"@bold", MASK, OWL_FMTEXT_ATTR_BOLD},
+    {"@b", MASK, OWL_FMTEXT_ATTR_BOLD},
+    {"@italic", MASK, OWL_FMTEXT_ATTR_UNDERLINE},
+    {"@i", MASK, OWL_FMTEXT_ATTR_UNDERLINE},
+    {"@roman", SET, OWL_FMTEXT_ATTR_NONE},
     {NULL, 0},
   };
 
@@ -574,7 +576,11 @@ static void owl_fmtext_append_ztext_tree(owl_fmtext *f, ztext_env *tree, char at
 
   for (i = 0; TAGS[i].tag != NULL; i++) {
     if (!strcasecmp(tree->label, TAGS[i].tag)) {
-      attr |= TAGS[i].mask;
+      if (TAGS[i].mode == MASK) {
+        attr |= TAGS[i].val;
+      } else if (TAGS[i].mode == SET) {
+        attr = TAGS[i].val;
+      }
       handled = true;
       break;
     }

--- a/owl.h
+++ b/owl.h
@@ -62,6 +62,7 @@ typedef struct _owl_fake_HV HV;
 #endif
 
 #include "window.h"
+#include "ztext.h"
 
 extern const char *version;
 

--- a/perl/lib/BarnOwl.pm
+++ b/perl/lib/BarnOwl.pm
@@ -108,6 +108,10 @@ sub zephyr_zwrite {
 
 Strips zephyr formatting from a string and returns the result
 
+=head2 ztext_protect STRING
+
+Massage zephyr formatting to make it not interfere with more zephyr formatting.
+
 =head2 zephyr_getsubs
 
 Returns the list of subscription triples <class,instance,recipient>,

--- a/perl/lib/BarnOwl.pm
+++ b/perl/lib/BarnOwl.pm
@@ -106,7 +106,11 @@ sub zephyr_zwrite {
 
 =head2 ztext_stylestrip STRING
 
-Strips zephyr formatting from a string and returns the result
+Strips zephyr formatting barnowl understands from a string and returns the result
+
+=head2 ztext_stylestrip_full STRING
+
+Strips all the zephyr formatting from a string an returns the reuslt
 
 =head2 ztext_protect STRING
 

--- a/perl/lib/BarnOwl/Style.pm
+++ b/perl/lib/BarnOwl/Style.pm
@@ -13,19 +13,7 @@ use BarnOwl::Style::OneLine;
 sub boldify
 {
     local $_ = shift;
-    if ( !(/\)/) ) {
-        return '@b(' . $_ . ')';
-    } elsif ( !(/\>/) ) {
-        return '@b<' . $_ . '>';
-    } elsif ( !(/\}/) ) {
-        return '@b{' . $_ . '}';
-    } elsif ( !(/\]/) ) {
-        return '@b[' . $_ . ']';
-    } else {
-        my $txt = "\@b($_";
-        $txt =~ s/\)/\)\@b\[\)\]\@b\(/g;
-        return $txt . ')';
-    }
+    return '@b{' . BarnOwl::ztext_protect($_) . '}'
 }
 
 sub style_command {

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -109,6 +109,19 @@ ztext_stylestrip(ztext)
 		g_free(rv);
 
 const utf8 *
+ztext_protect(ztext)
+	const char *ztext
+	PREINIT:
+		char *rv = NULL;
+	CODE:
+		rv = ztext_protect(ztext);
+		RETVAL = rv;
+	OUTPUT:
+		RETVAL
+	CLEANUP:
+		g_free(rv);
+
+const utf8 *
 zephyr_smartstrip_user(in)
 	const char *in
 	PREINIT:

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -122,6 +122,21 @@ ztext_protect(ztext)
 		g_free(rv);
 
 const utf8 *
+ztext_stylestrip_full(ztext)
+	const char *ztext
+	PREINIT:
+		char *rv = NULL;
+	CODE:
+                ztext_env *tree = ztext_tree(ztext);
+		rv = ztext_strip(tree);
+                ztext_env_free(tree);
+		RETVAL = rv;
+	OUTPUT:
+		RETVAL
+	CLEANUP:
+		g_free(rv);
+
+const utf8 *
 zephyr_smartstrip_user(in)
 	const char *in
 	PREINIT:

--- a/tester.c
+++ b/tester.c
@@ -1155,6 +1155,7 @@ int ztext_test(void)
                     "{- |foo| {'@bar{' |baz| {'@(' |bang}| ')'} '}'}}");
     CHECK_ZTEXT_STR("foo@bar{baz}", "{- |foo| {'@bar{' |baz| '}'}}");
     CHECK_ZTEXT_STR("@bloop", "{- |@bloop|}");
+    CHECK_ZTEXT_STR("@{)}@{>}", "{- {'@{' |)| '}'} {'@{' |>| '}'}}");
 
 #define CHECK_ZTEXT_STRIP(in, expected)                                      \
     do {                                                                     \
@@ -1178,6 +1179,7 @@ int ztext_test(void)
     CHECK_ZTEXT_STRIP("foo@bar{baz@(bang})}", "foobazbang}");
     CHECK_ZTEXT_STRIP("foo@bar{baz}", "foobaz");
     CHECK_ZTEXT_STRIP("@bloop", "@bloop");
+    CHECK_ZTEXT_STRIP("@{)}@{>}", ")>");
 
 #define CHECK_ZTEXT_RT(in)                                                \
     do {                                                                  \
@@ -1199,6 +1201,7 @@ int ztext_test(void)
     CHECK_ZTEXT_RT("foo@bar{baz@(bang})}");
     CHECK_ZTEXT_RT("foo@bar{baz}");
     CHECK_ZTEXT_RT("@bloop");
+    CHECK_ZTEXT_RT("@{)}@{>}");
 
     /* fuzzzzzz */
     srand48(getpid() + time(0));

--- a/tester.c
+++ b/tester.c
@@ -25,6 +25,7 @@ int owl_smartfilter_regtest(void);
 int owl_history_regtest(void);
 int call_filter_regtest(void);
 int owl_smartstrip_regtest(void);
+int ztext_test(void);
 
 extern void owl_perl_xs_init(pTHX);
 
@@ -117,6 +118,7 @@ int owl_regtest(void) {
   numfailures += owl_history_regtest();
   numfailures += call_filter_regtest();
   numfailures += owl_smartstrip_regtest();
+  numfailures += ztext_test();
   if (numfailures) {
       fprintf(stderr, "# *** WARNING: %d failures total\n", numfailures);
   }
@@ -1053,4 +1055,166 @@ int owl_smartstrip_regtest(void)
   printf("# END testing owl_zephyr_smartstripped_user\n");
 
   return numfailed;
+}
+
+static char *ztext_str(ztext_env *tree)
+{
+    /* Unambiguous representation of the parse tree */
+    char *s, *t, *u;
+
+    if (tree->opener) {
+        s = g_strdup_printf("{'%s%c'", tree->label, tree->opener);
+    } else {
+        s = g_strdup("{-");
+    }
+
+    for (ztext_node *p = tree->content; p != NULL; p = p->next) {
+        t = s;
+        if (p->type== ZTEXT_NODE_STRING) {
+            s = g_strdup_printf("%s |%s|", s, p->string);
+        } else if (p->type == ZTEXT_NODE_ENV) {
+            u = ztext_str(p->env);
+            s = g_strconcat(s, " ", u, NULL);
+            g_free(u);
+        }
+        g_free(t);
+    }
+
+    t = s;
+    if (tree->closer) {
+        s = g_strdup_printf("%s '%c'}", s, tree->closer);
+    } else {
+        s = g_strconcat(s, "}", NULL);
+    }
+    g_free(t);
+
+    return s;
+}
+
+char *ztext_ztext(ztext_env *tree)
+{
+    char *s, *t, *u;
+
+    if (tree->closer == '@' && tree->content == NULL)
+        return g_strdup("@@");
+
+    if (tree->opener) {
+        s = g_strdup_printf("%s%c", tree->label, tree->opener);
+    } else {
+        s = g_strdup("");
+    }
+
+    for (ztext_node *p = tree->content; p != NULL; p = p->next) {
+        t = s;
+        if (p->type == ZTEXT_NODE_STRING) {
+            s = g_strconcat(s, p->string, NULL);
+        } else if (p->type == ZTEXT_NODE_ENV) {
+            u = ztext_ztext(p->env);
+            s = g_strconcat(s, u, NULL);
+            g_free(u);
+        }
+        g_free(t);
+    }
+
+    if (tree->closer) {
+        t = s;
+        s = g_strdup_printf("%s%c", s, tree->closer);
+        g_free(t);
+    }
+
+    return s;
+}
+
+int ztext_test(void)
+{
+    int numfailed = 0;
+    char *s;
+    ztext_env *t;
+    char *d;
+
+#define CHECK_ZTEXT_STR(in, expected)                                         \
+    do {                                                                      \
+      t = ztext_tree(in);                                                     \
+      s = ztext_str(t);                                                       \
+      d = g_strdup_printf("ztext decode \"%s\" expected \"%s\" got \"%s\"",   \
+                          in, expected, s);                                   \
+      FAIL_UNLESS(d, !strcmp(s, expected));                                   \
+      ztext_env_free(t);                                                      \
+      g_free(d);                                                              \
+      g_free(s);                                                              \
+    } while (0)
+
+    CHECK_ZTEXT_STR("", "{-}");
+    CHECK_ZTEXT_STR("foo", "{- |foo|}");
+    CHECK_ZTEXT_STR("@{foo}", "{- {'@{' |foo| '}'}}");
+    CHECK_ZTEXT_STR("@bar{foo}", "{- {'@bar{' |foo| '}'}}");
+    CHECK_ZTEXT_STR("@bar{foo@bar}", "{- {'@bar{' |foo@bar| '}'}}");
+    CHECK_ZTEXT_STR("@bar{foo@@bar}", "{- {'@bar{' |foo| {'@@' '@'} |bar| '}'}}");
+    CHECK_ZTEXT_STR("@{foo@}bar}baz", "{- {'@{' |foo@| '}'} |bar}baz|}");
+    CHECK_ZTEXT_STR("foo@bar{baz@(bang})}",
+                    "{- |foo| {'@bar{' |baz| {'@(' |bang}| ')'} '}'}}");
+    CHECK_ZTEXT_STR("foo@bar{baz}", "{- |foo| {'@bar{' |baz| '}'}}");
+    CHECK_ZTEXT_STR("@bloop", "{- |@bloop|}");
+
+#define CHECK_ZTEXT_STRIP(in, expected)                                      \
+    do {                                                                     \
+      t = ztext_tree(in);                                                    \
+      s = ztext_strip(t);                                                    \
+      d = g_strdup_printf("ztext strip \"%s\" expected \"%s\" got \"%s\"",   \
+                          in, expected, s);                                  \
+      FAIL_UNLESS(d, !strcmp(s, expected));                                  \
+      ztext_env_free(t);                                                     \
+      g_free(d);                                                             \
+      g_free(s);                                                             \
+    } while (0)
+
+    CHECK_ZTEXT_STRIP("", "");
+    CHECK_ZTEXT_STRIP("foo", "foo");
+    CHECK_ZTEXT_STRIP("@{foo}", "foo");
+    CHECK_ZTEXT_STRIP("@bar{foo}", "foo");
+    CHECK_ZTEXT_STRIP("@bar{foo@bar}", "foo@bar");
+    CHECK_ZTEXT_STRIP("@bar{foo@@bar}", "foo@bar");
+    CHECK_ZTEXT_STRIP("@{foo@}bar}baz", "foo@bar}baz");
+    CHECK_ZTEXT_STRIP("foo@bar{baz@(bang})}", "foobazbang}");
+    CHECK_ZTEXT_STRIP("foo@bar{baz}", "foobaz");
+    CHECK_ZTEXT_STRIP("@bloop", "@bloop");
+
+#define CHECK_ZTEXT_RT(in)                                                \
+    do {                                                                  \
+      t = ztext_tree(in);                                                 \
+      s = ztext_ztext(t);                                                 \
+      d = g_strdup_printf("ztext round-trip \"%s\" got \"%s\"", in, s);   \
+      FAIL_UNLESS(d, !strcmp(s, in));                                     \
+      ztext_env_free(t);                                                  \
+      g_free(s);                                                          \
+    } while (0)
+
+    CHECK_ZTEXT_RT("");
+    CHECK_ZTEXT_RT("foo");
+    CHECK_ZTEXT_RT("@{foo}");
+    CHECK_ZTEXT_RT("@bar{foo}");
+    CHECK_ZTEXT_RT("@bar{foo@bar}");
+    CHECK_ZTEXT_RT("@bar{foo@@bar}");
+    CHECK_ZTEXT_RT("@{foo@}bar}baz");
+    CHECK_ZTEXT_RT("foo@bar{baz@(bang})}");
+    CHECK_ZTEXT_RT("foo@bar{baz}");
+    CHECK_ZTEXT_RT("@bloop");
+
+    /* fuzzzzzz */
+    srand48(getpid() + time(0));
+
+    char tango[32];
+    const char CHARS[] = "@abc ({<[]>})";
+
+    for(int i=0; i < 1000; i++) {
+        memset(tango, 0, sizeof(tango));
+        int l = lrand48() % sizeof(tango);
+        for (int j=0; j < l; j++) {
+            tango[j] = CHARS[lrand48() % (sizeof(CHARS) -1)];
+        }
+        CHECK_ZTEXT_RT(tango);
+    }
+
+
+    return numfailed;
 }

--- a/tester.c
+++ b/tester.c
@@ -1180,6 +1180,7 @@ int ztext_test(void)
     CHECK_ZTEXT_STRIP("foo@bar{baz}", "foobaz");
     CHECK_ZTEXT_STRIP("@bloop", "@bloop");
     CHECK_ZTEXT_STRIP("@{)}@{>}", ")>");
+    CHECK_ZTEXT_STRIP("@color(blue)@font(fixed)marzipan", "marzipan");
 
 #define CHECK_ZTEXT_RT(in)                                                \
     do {                                                                  \

--- a/tester.c
+++ b/tester.c
@@ -1218,6 +1218,21 @@ int ztext_test(void)
         CHECK_ZTEXT_RT(tango);
     }
 
+#define CHECK_ZTEXT_PROTECT(in, expected)                                     \
+    do {                                                                      \
+      s = ztext_protect(in);                                                  \
+      d = g_strdup_printf("ztext protect \"%s\" expected \"%s\" got \"%s\"",  \
+                          in, expected, s);                                   \
+      FAIL_UNLESS(d, !strcmp(s, expected));                                   \
+      g_free(d);                                                              \
+      g_free(s);                                                              \
+    } while (0)
+
+    CHECK_ZTEXT_PROTECT("", "");
+    CHECK_ZTEXT_PROTECT("foo", "foo");
+    CHECK_ZTEXT_PROTECT("fo}o", "fo@(})o");
+    CHECK_ZTEXT_PROTECT("@[foo", "@[foo]");
+    CHECK_ZTEXT_PROTECT("})>]", "@(})@<)>@[>]@{]}");
 
     return numfailed;
 }

--- a/ztext.c
+++ b/ztext.c
@@ -212,14 +212,18 @@ char *ztext_strip(ztext_env *tree) {
 
     for (ztext_node *p = tree->content; p != NULL; p = p->next) {
         t = s;
-        if (p->type== ZTEXT_NODE_STRING) {
+        if (p->type == ZTEXT_NODE_STRING) {
             s = g_strconcat(s, p->string, NULL);
+            g_free(t);
         } else if (p->type == ZTEXT_NODE_ENV) {
-            u = ztext_strip(p->env);
-            s = g_strconcat(s, u, NULL);
-            g_free(u);
+            if (!(!strcasecmp(p->env->label, "@color") ||
+                  !strcasecmp(p->env->label, "@font"))) {
+                u = ztext_strip(p->env);
+                s = g_strconcat(s, u, NULL);
+                g_free(u);
+                g_free(t);
+            }
         }
-        g_free(t);
     }
 
     return s;

--- a/ztext.c
+++ b/ztext.c
@@ -1,0 +1,323 @@
+#include "owl.h"
+#include "ztext.h"
+
+#include <assert.h>
+
+static const char MATCH[256] = {
+    ['('] = ')',
+    ['<'] = '>',
+    ['['] = ']',
+    ['{'] = '}',
+};
+
+enum { /*noproto*/
+    NEXT, // next slot is next state
+    TEXTC,
+    LABELC,
+    UNSAVE,
+    EMIT,
+    CLEAR,
+    PUSH,
+    POP,
+    JNMATCH, // next slot is where to go if the stack is not a match
+    JNSAVED, // ""
+    MAX_OPS,
+};
+
+static const char *opname[MAX_OPS]= {
+    [NEXT] = "NEXT",
+    [TEXTC] = "TEXTC",
+    [LABELC] = "LABELC",
+    [UNSAVE] = "UNSAVE",
+    [EMIT] = "EMIT",
+    [CLEAR] = "CLEAR",
+    [PUSH] = "PUSH",
+    [POP] = "POP",
+    [JNMATCH] = "JNMATCH",
+    [JNSAVED] = "JNSAVED",
+};
+
+static const unsigned char machine[2][256][16] = {
+    [0] = {
+        [0 ... 255] = {TEXTC, NEXT, 0},
+        [0] = {EMIT, NEXT, 0},
+        ['@'] = {LABELC, NEXT, 1},
+        [')'] = {JNMATCH, 5, EMIT, POP, NEXT, 0, TEXTC, NEXT, 0},
+        ['>'] = {JNMATCH, 5, EMIT, POP, NEXT, 0, TEXTC, NEXT, 0},
+        [']'] = {JNMATCH, 5, EMIT, POP, NEXT, 0, TEXTC, NEXT, 0},
+        ['}'] = {JNMATCH, 5, EMIT, POP, NEXT, 0, TEXTC, NEXT, 0},
+    },
+    [1] = {
+        [0 ... 255] = {UNSAVE, CLEAR, TEXTC, NEXT, 0},
+        [0] = {UNSAVE, EMIT, NEXT, 0},
+        ['@'] = {JNSAVED, 7, EMIT, CLEAR, PUSH, POP, NEXT, 0, UNSAVE, CLEAR, TEXTC, NEXT, 0},
+        ['0' ... '9'] = {LABELC, NEXT, 1},
+        ['A' ... 'Z'] = {LABELC, NEXT, 1},
+        ['_'] = {LABELC, NEXT, 1},
+        ['a' ... 'z'] = {LABELC, NEXT, 1},
+        [')'] = {JNMATCH, 7, UNSAVE, CLEAR, EMIT, POP, NEXT, 0, UNSAVE, CLEAR, TEXTC, NEXT, 0},
+        ['>'] = {JNMATCH, 7, UNSAVE, CLEAR, EMIT, POP, NEXT, 0, UNSAVE, CLEAR, TEXTC, NEXT, 0},
+        [']'] = {JNMATCH, 7, UNSAVE, CLEAR, EMIT, POP, NEXT, 0, UNSAVE, CLEAR, TEXTC, NEXT, 0},
+        ['}'] = {JNMATCH, 7, UNSAVE, CLEAR, EMIT, POP, NEXT, 0, UNSAVE, CLEAR, TEXTC, NEXT, 0},
+        ['('] = {EMIT, PUSH, CLEAR, NEXT, 0},
+        ['<'] = {EMIT, PUSH, CLEAR, NEXT, 0},
+        ['['] = {EMIT, PUSH, CLEAR, NEXT, 0},
+        ['{'] = {EMIT, PUSH, CLEAR, NEXT, 0},
+    },
+};
+
+typedef struct _ztext_stack { /*noproto*/
+    char close;
+    ztext_env *env;
+    struct _ztext_stack *next;
+} ztext_stack;
+
+static ztext_env *ztext_env_new(char *label, char opener)
+{
+    ztext_env *p = g_slice_new(ztext_env);
+    p->label = label;
+    p->opener = opener;
+    p->closer = 0;
+    p->content = NULL;
+    p->tail = NULL;
+    return p;
+}
+
+void ztext_env_free(ztext_env *env)
+{
+    if (env->label)
+        g_free(env->label);
+    for (ztext_node *next, *p = env->content; p != NULL; p = next) {
+        next = p->next;
+        if (p->type == ZTEXT_NODE_STRING)
+            g_free(p->string);
+        else if (p->type == ZTEXT_NODE_ENV)
+            ztext_env_free(p->env);
+        else
+            assert(!"freeing ztext_node, type not a string or a leaf");
+        g_slice_free(ztext_node, p);
+    }
+    g_slice_free(ztext_env, env);
+}
+
+static void ztext_env_append(ztext_env *env, ztext_node *node)
+{
+    if (env->tail == NULL)
+        env->content = node;
+    else
+        env->tail->next = node;
+    env->tail = node;
+}
+
+static ztext_node *ztext_node_new(ztext_env *e, char *s) {
+    ztext_node *p = g_slice_new(ztext_node);
+    assert((s != NULL || e != NULL) && !(s != NULL && e != NULL));
+
+    if (s != NULL) {
+        p->type = ZTEXT_NODE_STRING;
+        p->string = s;
+    }
+
+    if (e != NULL) {
+        p->type = ZTEXT_NODE_ENV;
+        p->env = e;
+    }
+
+    p->next = NULL;
+
+    return p;
+}
+
+ztext_env *ztext_tree(const char *s)
+{
+    int state = 0;
+    int next;
+    int len = strlen(s);
+    char text[len + 1];
+    char save[len + 1];
+    int texti = 0;
+    int savei = 0;
+    ztext_stack *stack = NULL;
+    ztext_stack *p;
+    ztext_env *tree = ztext_env_new(g_strdup(""), 0);
+    ztext_env *cur = tree;
+    int debug = 0;
+
+    text[texti] = 0;
+    save[savei] = 0;
+
+    for(int i = 0; i <= len; i++) { /* <=: deliberately processing the '\0' */
+        if (debug) printf("'%s' %d %c\n", unctrl(s[i]), state, stack ? stack->close : '-');
+        const unsigned char *line = machine[state][(unsigned)s[i]];
+        next = -1;
+        for (int ip = 0; next == -1; ip++) {
+            if (debug) printf(" %s \"%s\" \"%s\"\n", opname[line[ip]], text, save);
+            switch (line[ip]) {
+            case NEXT:
+                next = line[ip + 1];
+                break;
+            case TEXTC:
+                text[texti++] = s[i];
+                text[texti] = 0;
+                break;
+            case LABELC:
+                save[savei++] = s[i];
+                save[savei] = 0;
+                break;
+            case UNSAVE:
+                if (savei) {
+                    texti += g_strlcpy(&text[texti], save,
+                                       sizeof(text) - texti);
+                }
+                break;
+            case EMIT:
+                if (texti) {
+                    texti = 0;
+                    ztext_env_append(cur, ztext_node_new(NULL, g_strdup(text)));
+                }
+                break;
+            case CLEAR:
+                save[savei] = 0;
+                savei = 0;
+                break;
+            case PUSH:
+                p = g_slice_new(ztext_stack);
+                p->close = MATCH[(unsigned)s[i]];
+                p->env = cur;
+                p->next = stack;
+                stack = p;
+                cur = ztext_env_new(g_strdup(save), s[i]);
+                ztext_env_append(stack->env, ztext_node_new((void *)cur, NULL));
+                break;
+            case POP:
+                cur->closer = s[i];
+                cur = stack->env;
+                p = stack;
+                stack = p->next;
+                g_slice_free(ztext_stack, p);
+                break;
+            case JNMATCH:
+                if (stack == NULL || stack->close != s[i])
+                    ip += line[ip + 1];
+                else
+                    ip += 1;
+                break;
+            case JNSAVED:
+                if (savei > 1)
+                    ip += line[ip + 1];
+                else
+                    ip += 1;
+                break;
+            default:
+                assert(!"unknown operation in state machine");
+                return NULL;
+            }
+        }
+        state = next;
+    }
+
+    return tree;
+}
+
+char *ztext_strip(ztext_env *tree) {
+    char *s, *t, *u;
+
+    if (tree->closer == '@' && tree->content == NULL)
+        return g_strdup("@");
+
+    s = g_strdup("");
+
+    for (ztext_node *p = tree->content; p != NULL; p = p->next) {
+        t = s;
+        if (p->type== ZTEXT_NODE_STRING) {
+            s = g_strconcat(s, p->string, NULL);
+        } else if (p->type == ZTEXT_NODE_ENV) {
+            u = ztext_strip(p->env);
+            s = g_strconcat(s, u, NULL);
+            g_free(u);
+        }
+        g_free(t);
+    }
+
+    return s;
+}
+
+#ifdef notmain
+char *ztext_ztext(ztext_env *tree) {
+    char *s, *t;
+
+    if (tree->closer == '@' && tree->content == NULL)
+        return g_strdup("@@");
+
+    if (tree->opener) {
+        s = g_strdup_printf("%s%c", tree->label, tree->opener);
+    } else {
+        s = g_strdup("");
+    }
+
+    for (ztext_node *p = tree->content; p != NULL; p = p->next) {
+        t = s;
+        if (p->type== ZTEXT_NODE_STRING) {
+            s = g_strconcat(s, p->string, NULL);
+        } else if (p->type == ZTEXT_NODE_ENV) {
+            s = g_strconcat(s, ztext_ztext(p->env), NULL);
+        }
+        g_free(t);
+    }
+
+    if (tree->closer) {
+        t = s;
+        s = g_strdup_printf("%s%c", s, tree->closer);
+        g_free(t);
+    }
+
+    return s;
+}
+
+static char *ztext_str(ztext_env *tree) {
+    /* Unambiguous representation of the parse tree */
+    char *s, *t;
+
+    if (tree->opener) {
+        s = g_strdup_printf("{'%s%c'", tree->label, tree->opener);
+    } else {
+        s = g_strdup("{-");
+    }
+
+    for (ztext_node *p = tree->content; p != NULL; p = p->next) {
+        t = s;
+        if (p->type== ZTEXT_NODE_STRING) {
+            s = g_strdup_printf("%s |%s|", s, p->string);
+        } else if (p->type == ZTEXT_NODE_ENV) {
+            s = g_strconcat(s, " ", ztext_str(p->env), NULL);
+        }
+        g_free(t);
+    }
+
+    t = s;
+    if (tree->closer) {
+        s = g_strdup_printf("%s '%c'}", s, tree->closer);
+    } else {
+        s = g_strconcat(s, "}", NULL);
+    }
+    g_free(t);
+
+    return s;
+}
+
+int notmain(int argc, char *argv[]) {
+    if (argc != 2) {
+        printf("?%d\n", argc);
+        exit(1);
+    }
+    ztext_env *tree = ztext_tree(argv[1]);
+    char *s = ztext_ztext(tree);
+    printf("%s\n", s);
+    g_free(s);
+    s = ztext_str(tree);
+    printf("%s\n", s);
+    g_free(s);
+    ztext_env_free(tree);
+    return 0;
+}
+#endif

--- a/ztext.h
+++ b/ztext.h
@@ -1,0 +1,25 @@
+#ifndef INC_BARNOWL_ZTEXT_H
+#define INC_BARNOWL_ZTEXT_H
+
+typedef enum {
+    ZTEXT_NODE_ENV,
+    ZTEXT_NODE_STRING,
+} ztext_node_type;
+
+typedef struct _ztext_env {
+    char *label;
+    char opener;
+    char closer;
+    struct _ztext_node *content;
+    struct _ztext_node *tail;
+} ztext_env;
+
+typedef struct _ztext_node {
+    ztext_node_type type;
+    union {
+        struct _ztext_env *env;
+        char *string;
+    };
+    struct _ztext_node *next;
+} ztext_node;
+#endif


### PR DESCRIPTION
While investigating something that turned out to be trac ticket #188, I looked at owl_fmtext_append_ztext and found that I couldn't unsee it, so here's a parser with a state machine that produces a syntax tree, that then gets rendered into fmtext.  This turned out not to fix the bug; herein also find a ztext_protect function that _can_ be used to fix the bug.  Also a zwgc-style code strip (that doesn't just strip environments that barnowl understands) and support for @roman (remove bold and underline).