### PR TITLE
PR #162, except putting the tweet URL in the :info popup

### DIFF
--- a/README
+++ b/README
@@ -54,7 +54,7 @@ Digest::SHA
 
 The Twitter module requires:
 
-HTML::Entities
+HTML::Entities (provided by HTML::Parser)
 Net::Twitter::Lite
 
 The WordWrap module requires:

--- a/perl/modules/Twitter/lib/BarnOwl/Message/Twitter.pm
+++ b/perl/modules/Twitter/lib/BarnOwl/Message/Twitter.pm
@@ -35,7 +35,8 @@ sub replycmd {
     } elsif(exists($self->{status_id})) {
         return BarnOwl::quote('twitter-atreply', $self->sender, $self->{status_id}, $self->account);
     } else {
-        return BarnOwl::quote('twitter-atreply', $self->sender, $self->account);
+        # Give a dummy status ID
+        return BarnOwl::quote('twitter-atreply', $self->sender, '', $self->account);
     }
 }
 

--- a/perl/modules/Twitter/lib/BarnOwl/Module/Twitter.pm
+++ b/perl/modules/Twitter/lib/BarnOwl/Module/Twitter.pm
@@ -242,7 +242,7 @@ sub twitter {
 
 BarnOwl::new_command(twitter => \&cmd_twitter, {
     summary     => 'Update Twitter from BarnOwl',
-    usage       => 'twitter [ACCOUNT] [MESSAGE]',
+    usage       => 'twitter [ACCOUNT [MESSAGE]]',
     description => 'Update Twitter on ACCOUNT. If MESSAGE is provided, use it as your status.'
     . "\nIf no ACCOUNT is provided, update all services which have publishing enabled."
     . "\nOtherwise, prompt for a status message to use."
@@ -258,7 +258,7 @@ BarnOwl::new_command('twitter-direct' => \&cmd_twitter_direct, {
 BarnOwl::new_command( 'twitter-atreply' => sub { cmd_twitter_atreply(@_); },
     {
     summary     => 'Send a Twitter @ message',
-    usage       => 'twitter-atreply USER [ACCOUNT]',
+    usage       => 'twitter-atreply USER [ID [ACCOUNT]]',
     description => 'Send a Twitter @reply Message to USER on ACCOUNT (defaults to default_sender,' 
     . "\nor first service if no default is provided)"
     }

--- a/perl/modules/Twitter/lib/BarnOwl/Module/Twitter.pm
+++ b/perl/modules/Twitter/lib/BarnOwl/Module/Twitter.pm
@@ -264,6 +264,15 @@ BarnOwl::new_command( 'twitter-atreply' => sub { cmd_twitter_atreply(@_); },
     }
 );
 
+BarnOwl::new_command( 'twitter-prefill' => sub { cmd_twitter_prefill(@_); },
+    {
+    summary     => 'Send a Twitter message with prefilled text',
+    usage       => 'twitter-prefill PREFILL [ID [ACCOUNT]]',
+    description => 'Send a Twitter message with initial text PREFILL on ACCOUNT (defaults to default_sender,' 
+    . "\nor first service if no default is provided)"
+    }
+);
+
 BarnOwl::new_command( 'twitter-retweet' => sub { cmd_twitter_retweet(@_) },
     {
     summary     => 'Retweet the current Twitter message',
@@ -355,6 +364,30 @@ sub cmd_twitter_atreply {
     BarnOwl::start_edit_win("Reply to \@" . $user . ($account->nickname ? (" on " . $account->nickname) : ""),
                             sub { $account->twitter_atreply($user, $id, shift) });
     BarnOwl::Editwin::insert_text("\@$user ");
+}
+
+sub cmd_twitter_prefill {
+    my $cmd  = shift;
+    # prefill is responsible for spacing
+    my $prefill = shift || die("Usage: $cmd PREFILL [In-Reply-To ID]\n");
+    my $id   = shift;
+    my $account = find_account_default(shift);
+
+    my $msg = "What's happening?";
+    if ($id) {
+        # So, this isn't quite semantically correct, but it's close
+        # enough, and under the planned use-case, it will look identical.
+        $msg = "Reply to " . $prefill;
+    }
+    if ($account->nickname) {
+        # XXX formatting slightly suboptimal on What's happening message;
+        # and the behavior does not match up with 'twitter' anyhoo,
+        # which doesn't dispatch through account_find_default
+        $msg .= " on " . $account->nickname;
+    }
+    BarnOwl::start_edit_win($msg,
+                            sub { $account->twitter_atreply(undef, $id, shift) });
+    BarnOwl::Editwin::insert_text($prefill);
 }
 
 sub cmd_twitter_retweet {

--- a/perl/modules/Twitter/lib/BarnOwl/Module/Twitter/Handle.pm
+++ b/perl/modules/Twitter/lib/BarnOwl/Module/Twitter/Handle.pm
@@ -289,6 +289,7 @@ sub poll_twitter {
             my $orig = $tweet->{retweeted_status};
             $orig = $tweet unless defined($orig);
 
+            my $url = $self->{cfg}->{service} . '/' . $orig->{user}{screen_name} . '/status/' . $tweet->{id};
             my $msg = BarnOwl::Message->new(
                 type      => 'Twitter',
                 sender    => $orig->{user}{screen_name},
@@ -298,6 +299,7 @@ sub poll_twitter {
                 location  => decode_entities($orig->{user}{location}||""),
                 body      => decode_entities($orig->{text}),
                 status_id => $tweet->{id},
+                url       => $url,
                 service   => $self->{cfg}->{service},
                 account   => $self->{cfg}->{account_nickname},
                 $tweet->{retweeted_status} ? (retweeted_by => $tweet->{user}{screen_name}) : ()


### PR DESCRIPTION
This PR takes @ezyang's first three commits from PR #162 (which I have not tested, but @andersk acked a few years ago), and replaces the fourth with a commit that puts the tweet URL in the `:info` popup instead of in the zsig field.