### PR TITLE
tester --builtin: Fix exit status

### DIFF
--- a/tester.c
+++ b/tester.c
@@ -84,8 +84,6 @@ int main(int argc, char **argv, char **env)
     eval_pv("use File::Spec; do File::Spec->rel2abs($main::test_prog); die($@) if($@)", true);
   }
 
-  status = 0;
-
   FREETMPS;
   LEAVE;
 


### PR DESCRIPTION
The exit status of `tester --builtin` previously came from the return value of `owl_regtest()`, but commit 95414bfd3960e215dd54e6916a12f56abbf0c820 accidentally overwrote it with 0.