### PR TITLE
Experimental Zulip support

### DIFF
--- a/perl/lib/BarnOwl.pm
+++ b/perl/lib/BarnOwl.pm
@@ -8,7 +8,7 @@ our @EXPORT_OK = qw(command getcurmsg getnumcols getnumlines getidletime
                     register_idle_watcher unregister_idle_watcher
                     zephyr_getsender zephyr_getrealm zephyr_zwrite
                     zephyr_stylestrip zephyr_smartstrip_user zephyr_getsubs
-                    queue_message admin_message
+                    queue_message get_message_by_id admin_message
                     start_edit
                     start_question start_password start_edit_win
                     get_data_dir get_config_dir popless_text popless_ztext

--- a/perl/lib/BarnOwl/Message.pm
+++ b/perl/lib/BarnOwl/Message.pm
@@ -101,18 +101,18 @@ sub serialize {
     my ($this) = @_;
     my $s;
     for my $f (keys %$this) {
-	my $val = $this->{$f};
-	if (ref($val) eq "ARRAY") {
-	    for my $i (0..@$val-1) {
-		my $aval;
-		$aval = $val->[$i];
-		$aval =~ s/\n/\n$f.$i: /g;
-		$s .= "$f.$i: $aval\n";
-	    }
-	} else {
-	    $val =~ s/\n/\n$f: /g;
-	    $s .= "$f: $val\n";
-	}
+        my $val = $this->{$f};
+        if (ref($val) eq "ARRAY") {
+            for my $i (0..@$val-1) {
+                my $aval;
+                $aval = $val->[$i];
+                $aval =~ s/\n/\n$f.$i: /g;
+                $s .= "$f.$i: $aval\n";
+            }
+        } else {
+            $val =~ s/\n/\n$f: /g;
+            $s .= "$f: $val\n";
+        }
     }
     return $s;
 }
@@ -303,11 +303,11 @@ sub legacy_populate_global {
     $BarnOwl::login      = $m->login     ;
     $BarnOwl::auth       = $m->auth      ;
     if ($m->fields) {
-	@BarnOwl::fields = @{$m->fields};
-	@main::fields = @{$m->fields};
+        @BarnOwl::fields = @{$m->fields};
+        @main::fields = @{$m->fields};
     } else {
-	@BarnOwl::fields = undef;
-	@main::fields = undef;
+        @BarnOwl::fields = undef;
+        @main::fields = undef;
     }
 }
 
@@ -330,3 +330,7 @@ sub subcontext {""}
 
 
 1;
+
+# Local Variables:
+# indent-tabs-mode: nil
+# End:

--- a/perl/modules/Makefile.am
+++ b/perl/modules/Makefile.am
@@ -1,4 +1,4 @@
-MODULES = Jabber IRC WordWrap Twitter Facebook Kerberos
+MODULES = Jabber IRC WordWrap Twitter Facebook Kerberos Zulip
 
 EXTRA_DIST = $(MODULES:=/Makefile.PL) $(MODULES:=/lib)
 EXTRA_DIST += \

--- a/perl/modules/Zulip/README
+++ b/perl/modules/Zulip/README
@@ -1,3 +1,5 @@
+-*- text -*-
+
 BarnOwl::Module::Zulip is a terminal client for the Zulip
 (https://zulip.org/) chat system. Zulip is influenced heavily by
 Zephyr and so BarnOwl is a pretty good match for it.
@@ -124,6 +126,9 @@ OTHER DEVELOPMENT WORK:
 
 - code cleanup (kill globals with fire, refactor long functions,
   possibly break out some modules?)
+
+- Probably break out AnyEvent::Zulip into a separate module that this
+  just uses
 
 - get this merged into barnowl mainline, especially now that it has an
   XS change (i.e. it's not just a drop-in PAR anymore)

--- a/perl/modules/Zulip/README
+++ b/perl/modules/Zulip/README
@@ -2,10 +2,13 @@ BarnOwl::Module::Zulip is a terminal client for the Zulip
 (https://zulip.org/) chat system. Zulip is influenced heavily by
 Zephyr and so BarnOwl is a pretty good match for it.
 
+
 PREREQUISITES
 
 - all the normal BarnOwl dependencies, including PAR and AnyEvent::HTTP
+
 - URI::Encode
+
 
 SETUP
 
@@ -34,11 +37,88 @@ If your Zulip instance requires SSL client credentials, specify the
 paths to the certificate and key as "cert_file" and "key_file",
 respectively, under "ssl".
 
-MISSING FEATURES:
 
-- backfilling from history
-- smartnarrow (needs to be ported from the Zephyr smartnarrow in C)
-- better handling of personals with multiple recipients
-- editing messages (barnowl will show message edits from other people)
+USAGE
+
+When you start BarnOwl, you should run "zulip:login". Or put it at the
+end of ~/.owl/startup.
+
+
+FEATURES:
+
+- sending and receiving zulip stream and personal messages (including
+  with multiple recipients, mostly-functionally)
+
+- listing, adding, and removing subscriptions
+
+- minimal support for stream creation (if you try to sub to a stream
+  that doesn't exist, it'll _probably_ create a new one with whatever
+  your site's default settings are)
+
+- full filter language support (message attributes are mostly the same
+  as zephyr) including support for "punt" and mostly-functional
+  smartfilter.
+
+- support for displaying message edits (they show up as new messages
+  with the correct stream/topic/sender with the new text and opcode
+  EDIT)
+
+MISSING/UNFINISHED FEATURES:
+
+- backfilling from history (this will be hard. barnowl currently only
+  supports appending to the msglist from perl, and I think the msglist
+  is also an array, so that's potential badness)
+
+- smartnarrow robustness (has been ported from C, but almost certainly
+  still has weird corner cass)
+
+- better handling of personals with multiple recipients (I think Alex
+  implemented this, but more testing is never bad)
+
 - syncing the curmsg pointer with the server
-- sending presence more cleverly (right now it just sends a ping every minute regardless of how active you are)
+
+- sending presence more cleverly (right now it just sends a ping every
+  minute regardless of how active you are)
+
+- deleting messages is probably interestingly broken right now w/r/t
+  the hash of zid -> barnowl message id. make it work.
+
+- being able to view user presence (ala zlocate/aim buddy list/jabber
+  roster/etc)
+
+- being able to invite people to invite-only streams
+
+FEATURES THAT SHOULD PROBABLY EXIST BUT THAT I DON'T REALLY CARE ABOUT
+MUCH
+
+- editing messages
+
+- option to allow in-place update of edited messages instead of adding
+  a new message
+
+- being able to create a stream with options (e.g. invite-only) set
+
+- being able to edit attributes of streams (zephyr doesn't have 'em,
+  but zulip does)
+
+- being able to delete streams
+
+- being able to see a list of people subscribed to a given stream
+
+
+FEATURES THAT WOULD BE HILARIOUS
+
+- zcrypt support
+
+
+OTHER DEVELOPMENT WORK:
+
+- general robustness (e.g. if you try to zulip:login again after
+  do_poll has given up (because the server went away and didn't come
+  back in a reasonable time, it probably crashes hard.)
+
+- code cleanup (kill globals with fire, refactor long functions,
+  possibly break out some modules?)
+
+- get this merged into barnowl mainline, especially now that it has an
+  XS change (i.e. it's not just a drop-in PAR anymore)

--- a/perl/modules/Zulip/README
+++ b/perl/modules/Zulip/README
@@ -63,6 +63,7 @@ FEATURES:
   with the correct stream/topic/sender with the new text and opcode
   EDIT)
 
+
 MISSING/UNFINISHED FEATURES:
 
 - backfilling from history (this will be hard. barnowl currently only
@@ -87,6 +88,10 @@ MISSING/UNFINISHED FEATURES:
   roster/etc)
 
 - being able to invite people to invite-only streams
+
+- improved URL generation. We shouldn't have to warn people not to
+  have a trailing / in their api_url setting.
+
 
 FEATURES THAT SHOULD PROBABLY EXIST BUT THAT I DON'T REALLY CARE ABOUT
 MUCH

--- a/perl/modules/Zulip/README
+++ b/perl/modules/Zulip/README
@@ -1,0 +1,43 @@
+BarnOwl::Module::Zulip is a terminal client for the Zulip
+(https://zulip.org/) chat system. Zulip is influenced heavily by
+Zephyr and so BarnOwl is a pretty good match for it.
+
+PREREQUISITES
+
+- all the normal BarnOwl dependencies, including PAR and AnyEvent::HTTP
+- URI::Encode
+
+SETUP
+
+You'll need to get your personal API key from Zulip. You can find this
+on your "settings" page.
+
+To use BarnOwl::Module::Zulip, create a file called "zulip" in
+~/.owl. The contents of this file should be a JSON dictionary:
+
+{ "user": <the email address you use to log into Zulip>,
+  "apikey": <your personal API key>,
+  "api_url": <the API URL root for your Zulip instance. Should look something like 'https://chat.zulip.org/api/v1'. MUST NOT have a trailing / right now>,
+  "default_realm": <optionally, the domain name you expect most users on your realm to have usernames under. Convenience feature for letting you send personals with less typing>
+}
+
+If your Zulip instance uses HTTPS (as it should), it is optional (but *HIGHLY RECOMMENDED*) to specify an additional set of options in the dictionary:
+
+{ "user": <same as before>,
+  ...
+  "ssl": {
+           "ca_file": <path to your system's list of trusted root SSL certificates. It's /etc/ssl/certs/ca-certificates.crt on Ubuntu or Debian>
+	  }
+}
+
+If your Zulip instance requires SSL client credentials, specify the
+paths to the certificate and key as "cert_file" and "key_file",
+respectively, under "ssl".
+
+MISSING FEATURES:
+
+- subscription manipulation
+- backfilling from history
+- smartnarrow (needs to be ported from the Zephyr smartnarrow in C)
+- better handling of personals with multiple recipients
+- message edits (both making and displaying)

--- a/perl/modules/Zulip/README
+++ b/perl/modules/Zulip/README
@@ -36,7 +36,6 @@ respectively, under "ssl".
 
 MISSING FEATURES:
 
-- subscription manipulation
 - backfilling from history
 - smartnarrow (needs to be ported from the Zephyr smartnarrow in C)
 - better handling of personals with multiple recipients

--- a/perl/modules/Zulip/README
+++ b/perl/modules/Zulip/README
@@ -40,4 +40,6 @@ MISSING FEATURES:
 - backfilling from history
 - smartnarrow (needs to be ported from the Zephyr smartnarrow in C)
 - better handling of personals with multiple recipients
-- message edits (both making and displaying)
+- editing messages (barnowl will show message edits from other people)
+- syncing the curmsg pointer with the server
+- sending presence (so you don't get "missed message" emails)

--- a/perl/modules/Zulip/README
+++ b/perl/modules/Zulip/README
@@ -41,4 +41,4 @@ MISSING FEATURES:
 - better handling of personals with multiple recipients
 - editing messages (barnowl will show message edits from other people)
 - syncing the curmsg pointer with the server
-- sending presence (so you don't get "missed message" emails)
+- sending presence more cleverly (right now it just sends a ping every minute regardless of how active you are)

--- a/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
@@ -169,15 +169,13 @@ sub smartfilter {
 	if($inst) {
 	    $filter .= "-instance-$instance";
 	}
-	$class = BarnOwl::quote(quote_for_filter($class));
+	$class = quote_for_filter($class);
 	# TK deal with filter already existing
-	my $filter_str = "";
-	$filter_str .= ($related ? "class ^(un)*${class}(\\.d)*\$" : "class ^${class}\$");
+	@filter = (($related ? ("class", "^(un)*${class}(\\.d)*\$") : ("class", "^${class}\$")));
 	if($inst) {
-	    $instance = BarnOwl::quote(quote_for_filter($instance));
-	    $filter_str .= ($related ? " and ( instance ^(un)*${instance}(\\.d)*\$ )" : " and ( instance ^${instance}\$ )");
+	    $instance = quote_for_filter($instance);
+	    push @filter, ($related ? (qw{ and ( instance }, "^(un)*${instance}(\\.d)*\$", ")") : (qw{ and ( instance }, "^${instance}\$", ")"));
 	}
-	@filter = split / /, $filter_str;
     }
     BarnOwl::command("filter", $filter, @filter);
     return $filter;

--- a/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+
+package BarnOwl::Message::Zulip;
+use base qw(BarnOwl::Message);
+
+use BarnOwl::Module::Zulip qw(default_realm);
+
+
+sub strip_realm {
+    my $sender = shift;
+    my $realm = BarnOwl::Module::Zulip::default_realm();
+    $sender =~ s/\@\Q$realm\E$//;
+    return $sender;
+}
+
+sub context {
+    return shift->class;
+}
+
+sub subcontext {
+    return shift->instance;
+}
+
+sub pretty_sender {
+    my ($m) = @_;
+    return strip_realm($m->sender);
+}
+
+sub pretty_recipient {
+    my ($m) = @_;
+    return strip_realm($m->recipient);
+}
+
+sub class       { return shift->{"class"}; }
+sub instance    { return shift->{"instance"}; }
+sub realm       { return shift->{"realm"}; }
+sub long_sender        { return shift->{"sender_full_name"}; }
+sub zid { return shift->{zid}; }
+
+sub replycmd {
+    my $self = shift;
+    if ($self->is_private) {
+	return $self->replysendercmd;
+    } else {
+	return BarnOwl::quote("zulip:write", "-c", $self->class, 
+			      "-i", $self->instance);
+    }
+}
+
+sub replysendercmd {
+    my $self = shift;
+    return BarnOwl::quote("zulip:write", $self->sender);
+}
+
+1;

--- a/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
@@ -44,8 +44,8 @@ sub replycmd {
     if ($self->is_private) {
 	return $self->replysendercmd;
     } else {
-	return BarnOwl::quote("zulip:write", "-c", $self->class, 
-			      "-i", $self->instance);
+        return BarnOwl::quote("zulip:write", "-c", $self->class,
+                              "-i", $self->instance);
     }
 }
 

--- a/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
@@ -35,6 +35,7 @@ sub pretty_recipient {
 sub class       { return shift->{"class"}; }
 sub instance    { return shift->{"instance"}; }
 sub realm       { return shift->{"realm"}; }
+sub opcode       { return shift->{"opcode"}; }
 sub long_sender        { return shift->{"sender_full_name"}; }
 sub zid { return shift->{zid}; }
 

--- a/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Message/Zulip.pm
@@ -32,6 +32,11 @@ sub pretty_recipient {
     return strip_realm($m->recipient);
 }
 
+sub private_recipient_list {
+    my ($m) = @_;
+    return split(/ /, $m->recipient);
+}
+
 sub class       { return shift->{"class"}; }
 sub instance    { return shift->{"instance"}; }
 sub realm       { return shift->{"realm"}; }
@@ -42,7 +47,7 @@ sub zid { return shift->{zid}; }
 sub replycmd {
     my $self = shift;
     if ($self->is_private) {
-	return $self->replysendercmd;
+        return $self->replyprivate(1);
     } else {
         return BarnOwl::quote("zulip:write", "-c", $self->class,
                               "-i", $self->instance);
@@ -51,7 +56,44 @@ sub replycmd {
 
 sub replysendercmd {
     my $self = shift;
-    return BarnOwl::quote("zulip:write", $self->sender);
+    if ($self->is_private) {
+        return $self->replyprivate(0);
+    } else {
+        return BarnOwl::quote("zulip:write", $self->sender);
+    }
+}
+
+sub replyprivate {
+    # Cases:
+    # - me -> me: me
+    # - me -> other: other
+    # - (all) me -> other1, other2: other1, other2
+    # - (not) me -> other1, other2: error
+    # - other -> me: other
+    # - (all) other1 -> me, other2: other1, other2
+    # - (not) other1 -> me, other2: other1
+    my $self = shift;
+    my $all = shift;
+    my @recipients;
+    if ($all) {
+       @recipients = $self->private_recipient_list;
+    } else {
+        if ($self->sender eq BarnOwl::Module::Zulip::user()) {
+            @recipients = $self->private_recipient_list;
+            if (scalar(@recipients) > 1) {
+                BarnOwl::error("Cannot reply privately to message to more than one recipient");
+                return;
+            }
+        } else {
+            @recipients = $self->sender;
+        }
+    }
+    my @filtered_recipients = grep { $_ ne BarnOwl::Module::Zulip::user() } @recipients;
+    if (scalar(@filtered_recipients) == 0) {
+        # Self must have been only recipient, so re-add it (one copy)
+        @filtered_recipients = @recipients[0];
+    }
+    return BarnOwl::quote("zulip:write", @filtered_recipients);
 }
 
 1;

--- a/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
@@ -1,0 +1,281 @@
+use strict;
+use warnings;
+
+package BarnOwl::Module::Zulip;
+
+our $VERSION=0.1;
+our $queue_id;
+our $last_event_id;
+our %cfg;
+our $max_retries = 5;
+
+use AnyEvent;
+use AnyEvent::HTTP;
+use JSON;
+use MIME::Base64;
+use URI;
+use URI::Encode;
+use BarnOwl::Hooks;
+use BarnOwl::Message::Zulip;
+use HTTP::Request::Common;
+use Getopt::Long qw(GetOptionsFromArray);
+
+sub fail {
+    my $msg = shift;
+    undef %cfg;
+    undef $queue_id;
+    undef $last_event_id;
+
+    BarnOwl::admin_message('Zulip Error', $msg);
+    die("Zulip Error: $msg\n");
+}
+
+
+our $conffile = BarnOwl::get_config_dir() . "/zulip";
+
+if (open(my $fh, "<", "$conffile")) {
+    read_config($fh);
+    close($fh);
+}
+
+sub authorization {
+    return "Basic " . encode_base64($cfg{'user'} . ':' . $cfg{'apikey'}, "")
+}
+
+sub read_config {
+    my $fh = shift;
+
+    my $raw_cfg = do {local $/; <$fh>};
+    close($fh);
+    eval {
+        $raw_cfg = from_json($raw_cfg);
+    };
+    if($@) {
+        fail("Unable to parse $conffile: $@");
+    }
+
+    if(! exists $raw_cfg->{user}) {
+	fail("Account has no username set.");
+    }
+    my $user = $raw_cfg->{user};
+    if(! exists $raw_cfg->{apikey}) {
+	fail("Account has no api key set.");
+    }
+    my $apikey = $raw_cfg->{apikey};
+    if(! exists $raw_cfg->{api_url}) {
+	fail("Account has no API url set.");
+    }
+    my $api_url = $raw_cfg->{api_url};
+
+    if(! exists $raw_cfg->{default_realm}) {
+	fail("Account has no default realm set.");
+    }
+    my $default_realm = $raw_cfg->{default_realm};
+
+    $cfg{'user'} = $user;
+    $cfg{'apikey'} = $apikey;
+    $cfg{'api_url'} = $api_url;
+    $cfg{'realm'} = $default_realm;
+}
+
+sub register {
+    my $retry_count = 0;
+    BarnOwl::debug("In register");
+    my $callback;
+    $callback = sub {
+	BarnOwl::debug("In register callback");
+	my ($body, $headers) = @_;
+	if($headers->{Status} > 399) {
+	    warn "Failed to make event queue registration request ($headers->{Status})";
+	    if($retry_count >= $max_retries) {
+		fail("Giving up");
+	    } else {
+		$retry_count++;			      
+		http_post($cfg{'api_url'} . "/register", "",
+				    headers => { "Authorization" => authorization }, 
+				    $callback);
+		return;
+	    }
+	} else {
+	    my $response = decode_json($body);
+	    if($response->{result} ne "success") {
+		fail("Failed to register event queue; error was $response->{msg}");
+	    } else {
+		$last_event_id = $response->{last_event_id};
+		$queue_id = $response->{queue_id};
+		do_poll();
+		return;
+	    }
+	}
+    };
+    
+    http_post($cfg{'api_url'} . "/register", "",
+	      headers => { "Authorization" => authorization }, $callback);
+    return;
+}
+
+sub do_poll {
+    my $uri = URI->new($cfg{'api_url'} . "/events");
+    $uri->query_form("queue_id" => $queue_id, 
+		     "last_event_id" => $last_event_id);
+    my $retry_count = 0;
+    my $callback;
+    $callback = sub {
+	my ($body, $headers) = @_;
+	if($headers->{Status} > 399) {
+	    warn "Failed to poll for events: $headers->{Reason}";
+	    BarnOwl::debug($body);
+	    if($retry_count >= $max_retries) {
+		fail("do_poll: Giving up");
+	    } else {
+		$retry_count++;	      
+		http_get($uri->as_string, 
+				   "headers" => { "Authorization" => authorization }, 
+				   $callback);
+		return;
+	    }
+	} else {
+	    event_cb($body, $headers);
+	}
+    };
+    http_get($uri->as_string, "headers" => { "Authorization" => authorization }, $callback);
+    return;
+}
+
+sub event_cb {
+    my ($body, $headers) = @_;
+    my $response = decode_json($body);
+    if($response->{result} ne "success") {
+	fail("Failed to poll for events; error was $response->{msg}");
+    } else {
+	for my $event (@{$response->{events}}) {
+	    if($event->{type} eq "message") {
+		my $msg = $event->{message};
+		my %msghash = (
+		    type => 'Zulip',
+		    sender => $msg->{sender_email},
+		    recipient => $msg->{recipient_id},
+		    direction => 'in',
+		    class => $msg->{display_recipient},
+		    instance => $msg->{subject},
+		    unix_time => $msg->{timestamp},
+		    source => "zulip",
+		    location => "zulip",
+		    body => $msg->{content},
+		    zid => $msg->{id},
+		    sender_full_name => $msg->{sender_full_name});
+		if($msg->{type} eq "private") {
+		    $msghash{private} = 1;
+		    my @raw_recipients = @{$msg->{display_recipient}};
+		    my @display_recipients;
+		    if (scalar(@raw_recipients) > 1) {
+			my $recip;
+			for $recip (@raw_recipients) {
+			    unless ($recip->{email} eq $cfg{user}) {
+				push @display_recipients, $recip->{email};
+			    }
+			}
+			$msghash{recipient} = join " ", @display_recipients;
+		    } else {
+			$msghash{recipient} = $msg->{display_recipient}->[0]->{email};
+		    }
+		    $msghash{class} = "message";
+		    if($msg->{sender_email} eq $cfg{user}) {
+			$msghash{direction} = 'out';
+		    }
+		}
+		my $bomsg = BarnOwl::Message->new(%msghash);
+		BarnOwl::queue_message($bomsg);
+	    }
+	    $last_event_id = $event->{id};
+	    do_poll();
+	    return;
+	}
+    }
+    
+}
+
+sub zulip {
+    my ($type, $recipient, $subject, $msg) = @_;
+    # only care about it for its url encoding
+    my $builder = URI->new("http://www.example.com");
+    my %params = ("type" => $type, "to" => $recipient,  "content" => $msg);
+    if ($subject ne "") {
+    	$params{"subject"} = $subject;
+    }
+    my $url = $cfg{'api_url'} . "/messages";
+    my $req = POST($url, \%params); 
+    http_post($url, $req->content, "headers" => {"Authorization" => authorization, "Content-Type" => "application/x-www-form-urlencoded"}, sub { 
+	my ($body, $headers) = @_;
+	if($headers->{Status} < 400) {
+	    BarnOwl::message("Zulipgram sent");
+	} else {
+	    BarnOwl::message("Error sending zulipgram: $headers->{Reason}!");
+	    BarnOwl::debug($body);
+	}});
+    return;
+}
+
+sub cmd_zulip_login {
+    register();
+}
+
+sub cmd_zulip_write {
+    my $cmdline = join " ", @_;
+    my $cmd = shift;
+    my $stream;
+    my $subject;
+    my $type;
+    my $to;
+    my $ret = GetOptionsFromArray(\@_,
+			       "c:s" => \$stream,
+			       "i:s" => \$subject);
+    unless($ret) {
+	die("Usage: zulip:write [-c stream] [-i subject] [recipient] ...");
+    }
+    # anything left is a recipient
+    if (scalar(@_) > 0) {
+	my @addresses = map {
+	    if(/@/) {
+		$_;
+	    } else {
+		$_ . "\@$cfg{'realm'}";
+	    }} @_;
+	$to = encode_json(\@addresses);
+	$type = "private";
+	    
+    } else {
+	$type = "stream";
+	$to = $stream
+    }
+    BarnOwl::start_edit(prompt => $cmdline, type => 'edit_win', 
+			callback => sub {
+			    my ($text, $should_send) = @_;
+			    unless ($should_send) {
+				BarnOwl::message("zulip:write cancelled");
+				return;
+			    }
+			    zulip($type, $to, $subject, $text);
+			});
+    
+}
+
+BarnOwl::new_command('zulip:login' => sub { cmd_zulip_login(@_); },
+		     {
+			 summary => "Log in to Zulip",
+			 usage => "zulip:login",
+			 description => "Start receiving Zulip messages"
+		     });
+
+BarnOwl::new_command('zulip:write' => sub { cmd_zulip_write(@_); },
+		     {
+			 summary => "Send a zulipgram",
+			 usage => "zulip:login [-c stream] [-i subject] [recipient(s)]",
+			 description => "Send a zulipgram to a stream, person, or set of people"
+		     });
+
+sub default_realm {
+  return $cfg{'realm'};
+}
+
+1;

--- a/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
@@ -470,6 +470,9 @@ BarnOwl::new_command('zulip:unsubscribe' => sub { cmd_zulip_unsub(@_); },
                          description => "Unsubscribe to a Zulip stream"
                      });
 
+sub user {
+  return $cfg{'user'};
+}
 
 sub default_realm {
   return $cfg{'realm'};

--- a/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
@@ -125,8 +125,11 @@ sub read_config {
 
 sub register {
     my $retry_count = 0;
-    BarnOwl::debug("In register");
     my $callback;
+
+    if(!exists $cfg{'api_url'}) {
+        die("Zulip not configured, cannot poll for events");
+    }
     $callback = sub {
         BarnOwl::debug("In register callback");
         my ($body, $headers) = @_;

--- a/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
@@ -39,24 +39,24 @@ sub initialize {
     my $conffile = BarnOwl::get_config_dir() . "/zulip";
 
     if (open(my $fh, "<", "$conffile")) {
-	read_config($fh);
-	close($fh);
+        read_config($fh);
+        close($fh);
     }
     if ($cfg{'api_url'} =~ /^https/) {
-	if (exists $cfg{'ssl_key_file'}) {
-	    $tls_ctx = new AnyEvent::TLS(verify => $cfg{'ssl_verify'}, 
-					 sslv3 => 0, verify_peername => "http",
-					 ca_file => $cfg{'ssl_ca_file'},
-					 cert_file => $cfg{'ssl_cert_file'},
-					 key_file => $cfg{'ssl_key_file'});
-	} else {
-	    $tls_ctx = new AnyEvent::TLS(verify => $cfg{'ssl_verify'}, 
-					 sslv3 => 0, verify_peername => "http",
-					 ca_file => $cfg{'ssl_ca_file'});
-	}	    
+        if (exists $cfg{'ssl_key_file'}) {
+            $tls_ctx = new AnyEvent::TLS(verify => $cfg{'ssl_verify'}, 
+                                         sslv3 => 0, verify_peername => "http",
+                                         ca_file => $cfg{'ssl_ca_file'},
+                                         cert_file => $cfg{'ssl_cert_file'},
+                                         key_file => $cfg{'ssl_key_file'});
+        } else {
+            $tls_ctx = new AnyEvent::TLS(verify => $cfg{'ssl_verify'}, 
+                                         sslv3 => 0, verify_peername => "http",
+                                         ca_file => $cfg{'ssl_ca_file'});
+        }           
     } else {
-	# we still want it for a unique id
-	$tls_ctx = int(rand(1024));
+        # we still want it for a unique id
+        $tls_ctx = int(rand(1024));
     }
 }
 
@@ -78,40 +78,40 @@ sub read_config {
     }
 
     if(! exists $raw_cfg->{user}) {
-	fail("Account has no username set.");
+        fail("Account has no username set.");
     }
     my $user = $raw_cfg->{user};
     if(! exists $raw_cfg->{apikey}) {
-	fail("Account has no api key set.");
+        fail("Account has no api key set.");
     }
     my $apikey = $raw_cfg->{apikey};
     if(! exists $raw_cfg->{api_url}) {
-	fail("Account has no API url set.");
+        fail("Account has no API url set.");
     }
     my $api_url = $raw_cfg->{api_url};
 
     if(! exists $raw_cfg->{default_realm}) {
-	fail("Account has no default realm set.");
+        fail("Account has no default realm set.");
     }
     my $default_realm = $raw_cfg->{default_realm};
 
     if( exists $raw_cfg->{ssl}) {
-	# mandatory parameters
-	if (! exists $raw_cfg->{ssl}->{ca_file}) {
-	    fail("SSL parameters specified, but no CA file set");
-	}
-	$cfg{'ssl_ca_file'} = $raw_cfg->{ssl}->{ca_file};
-	$cfg{'ssl_verify'} = 1;
-	# optional parameters
-	if ( (exists $raw_cfg->{ssl}->{cert_file}) && exists $raw_cfg->{ssl}->{key_file}) {
-	    $cfg{'ssl_cert_file'} = $raw_cfg->{ssl}->{cert_file};
-	    $cfg{'ssl_key_file'} = $raw_cfg->{ssl}->{key_file};
-	}  else {
-	    warn "SSL parameters specified, but no client credentials set.";
-	}
+        # mandatory parameters
+        if (! exists $raw_cfg->{ssl}->{ca_file}) {
+            fail("SSL parameters specified, but no CA file set");
+        }
+        $cfg{'ssl_ca_file'} = $raw_cfg->{ssl}->{ca_file};
+        $cfg{'ssl_verify'} = 1;
+        # optional parameters
+        if ( (exists $raw_cfg->{ssl}->{cert_file}) && exists $raw_cfg->{ssl}->{key_file}) {
+            $cfg{'ssl_cert_file'} = $raw_cfg->{ssl}->{cert_file};
+            $cfg{'ssl_key_file'} = $raw_cfg->{ssl}->{key_file};
+        }  else {
+            warn "SSL parameters specified, but no client credentials set.";
+        }
     } else {
-	$cfg{'ssl_verify'} = 0;
-	warn "SSL parameters not specified. WILL NOT VERIFY SERVER CERTIFICATE";
+        $cfg{'ssl_verify'} = 0;
+        warn "SSL parameters not specified. WILL NOT VERIFY SERVER CERTIFICATE";
     }
     
     $cfg{'user'} = $user;
@@ -125,189 +125,189 @@ sub register {
     BarnOwl::debug("In register");
     my $callback;
     $callback = sub {
-	BarnOwl::debug("In register callback");
-	my ($body, $headers) = @_;
-	if($headers->{Status} > 399) {
-	    warn "Failed to make event queue registration request ($headers->{Status})";
-	    if($retry_count >= $max_retries) {
-		fail("Giving up");
-	    } else {
-		$retry_count++;			      
-		http_post($cfg{'api_url'} . "/register", "",
-			  session => $tls_ctx,
-			  sessionid => $tls_ctx,
-			  tls_ctx => $tls_ctx,
-			  headers => { "Authorization" => authorization }, 
-			  $callback);
-		return;
-	    }
-	} else {
-	    my $response = decode_json($body);
-	    if($response->{result} ne "success") {
-		fail("Failed to register event queue; error was $response->{msg}");
-	    } else {
-		$last_event_id = $response->{last_event_id};
-		$queue_id = $response->{queue_id};
-		do_poll();
-		return;
-	    }
-	}
+        BarnOwl::debug("In register callback");
+        my ($body, $headers) = @_;
+        if($headers->{Status} > 399) {
+            warn "Failed to make event queue registration request ($headers->{Status})";
+            if($retry_count >= $max_retries) {
+                fail("Giving up");
+            } else {
+                $retry_count++;                       
+                http_post($cfg{'api_url'} . "/register", "",
+                          session => $tls_ctx,
+                          sessionid => $tls_ctx,
+                          tls_ctx => $tls_ctx,
+                          headers => { "Authorization" => authorization }, 
+                          $callback);
+                return;
+            }
+        } else {
+            my $response = decode_json($body);
+            if($response->{result} ne "success") {
+                fail("Failed to register event queue; error was $response->{msg}");
+            } else {
+                $last_event_id = $response->{last_event_id};
+                $queue_id = $response->{queue_id};
+                do_poll();
+                return;
+            }
+        }
     };
     
     http_post($cfg{'api_url'} . "/register", "",
-	      headers => { "Authorization" => authorization }, 
-	      session => $tls_ctx,
-	      sessionid => $tls_ctx,
-	      tls_ctx => $tls_ctx,
-	      $callback);
+              headers => { "Authorization" => authorization }, 
+              session => $tls_ctx,
+              sessionid => $tls_ctx,
+              tls_ctx => $tls_ctx,
+              $callback);
     return;
 }
 
 sub parse_response {
     my ($body, $headers) = @_;
     if($headers->{Status} > 399) {
-	return 0;
+        return 0;
     }
     my $response = decode_json($body);
     if($response->{result} ne "success") {
-	return 0;
+        return 0;
     }
     return $response;
 }
 sub do_poll {
     my $uri = URI->new($cfg{'api_url'} . "/events");
     $uri->query_form("queue_id" => $queue_id, 
-		     "last_event_id" => $last_event_id);
+                     "last_event_id" => $last_event_id);
     my $retry_count = 0;
     my $callback;
     $callback = sub {
-	my ($body, $headers) = @_;
-	my $response = parse_response($body, $headers);
-	if(!$response) {
-	    warn "Failed to poll for events in do_poll: $headers->{Reason}";
-	    if($retry_count >= $max_retries) {
-		warn "Retry count exceeded in do_poll, giving up";
-		fail("do_poll: Giving up");
-	    } else {
-		warn "Retrying";
-		$retry_count++;	      
-		$retry_timer = AnyEvent->timer(after => 10, cb => sub { warn "retry number $retry_count"; 
-							 http_get($uri->as_string, 
-								  "headers" => { "Authorization" => authorization },
-								  session => $tls_ctx,
-								  sessionid => $tls_ctx,
-								  tls_ctx => $tls_ctx, 
-								  $callback);
-							 return;
-				});
-		return;
-	    }
-	} else {
-	    event_cb($response);
-	}
+        my ($body, $headers) = @_;
+        my $response = parse_response($body, $headers);
+        if(!$response) {
+            warn "Failed to poll for events in do_poll: $headers->{Reason}";
+            if($retry_count >= $max_retries) {
+                warn "Retry count exceeded in do_poll, giving up";
+                fail("do_poll: Giving up");
+            } else {
+                warn "Retrying";
+                $retry_count++;       
+                $retry_timer = AnyEvent->timer(after => 10, cb => sub { warn "retry number $retry_count"; 
+                                                         http_get($uri->as_string, 
+                                                                  "headers" => { "Authorization" => authorization },
+                                                                  session => $tls_ctx,
+                                                                  sessionid => $tls_ctx,
+                                                                  tls_ctx => $tls_ctx, 
+                                                                  $callback);
+                                                         return;
+                                });
+                return;
+            }
+        } else {
+            event_cb($response);
+        }
     };
     http_get($uri->as_string, "headers" => { "Authorization" => authorization }, 
-	     session => $tls_ctx,
-	     sessionid => $tls_ctx,
-	     tls_ctx => $tls_ctx,$callback);
+             session => $tls_ctx,
+             sessionid => $tls_ctx,
+             tls_ctx => $tls_ctx,$callback);
     return;
 }
 
 sub event_cb {
     my $response = $_[0];
     if($response->{result} ne "success") {
-	fail("event_cb: Failed to poll for events; error was $response->{msg}");
+        fail("event_cb: Failed to poll for events; error was $response->{msg}");
     } else {
-	for my $event (@{$response->{events}}) {
-	    if($event->{type} eq "message") {
-		my $msg = $event->{message};
-		my %msghash = (
-		    type => 'Zulip',
-		    sender => $msg->{sender_email},
-		    recipient => $msg->{recipient_id},
-		    direction => 'in',
-		    class => $msg->{display_recipient},
-		    instance => $msg->{subject},
-		    unix_time => $msg->{timestamp},
-		    source => "zulip",
-		    location => "zulip",
-		    body => $msg->{content},
-		    zid => $msg->{id},
-		    sender_full_name => $msg->{sender_full_name},
-		    opcode => "");
-		$msghash{'body'} =~ s/\r//gm;
-		if($msg->{type} eq "private") {
-		    $msghash{private} = 1;
-		    my @raw_recipients = @{$msg->{display_recipient}};
-		    my @display_recipients;
-		    if (scalar(@raw_recipients) > 1) {
-			my $recip;
-			for $recip (@raw_recipients) {
-			    unless ($recip->{email} eq $cfg{user}) {
-				push @display_recipients, $recip->{email};
-			    }
-			}
-			$msghash{recipient} = join " ", @display_recipients;
-		    } else {
-			$msghash{recipient} = $msg->{display_recipient}->[0]->{email};
-		    }
-		    $msghash{class} = "message";
-		    if($msg->{sender_email} eq $cfg{user}) {
-			$msghash{direction} = 'out';
-		    }
-		}
-		my $bomsg = BarnOwl::Message->new(%msghash);
-		# queue_message returns the message round-tripped
-		# through owl_message. In particular, this means it
-		# has a meaningful id.
-		my $rtmsg = BarnOwl::queue_message($bomsg);
-		# note that only base messages, not edits, end up in
-		# here. Tim promises me that we will never see an
-		# update to an update, so we shouldn't need to
-		# retrieve updated messages via this
-		$msg_id_map{$rtmsg->zid} = $rtmsg->id;
-	    } elsif($event->{type} eq "update_message") {
-		my $id = $event->{message_id};
-		if(!exists $msg_id_map{$id}) {
-		    BarnOwl::debug("Got update for unknown message $id, discarding");
-		} else {
-		    my $base_msg = BarnOwl::get_message_by_id($msg_id_map{$id});
-		    my %new_msghash = (
-			type => 'Zulip',
-			sender => $base_msg->sender,
-			recipient => $base_msg->recipient,
-			direction => $base_msg->direction,
-			class => $base_msg->class,
-			# instance needs to be potentially determined from new message
-			unix_time => $event->{edit_timestamp},
-			source => "zulip",
-			location => "zulip",
-			# content needs to be potentially determined from new message
-			zid => $base_msg->id,
-			sender_full_name => $base_msg->long_sender,
-			opcode => "EDIT");
-		    if (exists $$event{'subject'}) {
-			$new_msghash{'instance'} = $event->{subject};
-		    } else {
-			$new_msghash{'instance'} = $base_msg->instance;
-		    }
-		    if (exists $$event{'content'}) {
-			$new_msghash{'body'} = $event->{content};
-		    } else {
-			$new_msghash{'body'} = $base_msg->body;
-		    }
-		    my $bomsg = BarnOwl::Message->new(%new_msghash);
-		    BarnOwl::queue_message($bomsg);
-		}
-		
-	    } else {
-		BarnOwl::debug("Got unknown message");
-		BarnOwl::debug(encode_json($event));
-	    }
-	    $last_event_id = $event->{id};
-	    do_poll();
-	    return;
-	}
+        for my $event (@{$response->{events}}) {
+            if($event->{type} eq "message") {
+                my $msg = $event->{message};
+                my %msghash = (
+                    type => 'Zulip',
+                    sender => $msg->{sender_email},
+                    recipient => $msg->{recipient_id},
+                    direction => 'in',
+                    class => $msg->{display_recipient},
+                    instance => $msg->{subject},
+                    unix_time => $msg->{timestamp},
+                    source => "zulip",
+                    location => "zulip",
+                    body => $msg->{content},
+                    zid => $msg->{id},
+                    sender_full_name => $msg->{sender_full_name},
+                    opcode => "");
+                $msghash{'body'} =~ s/\r//gm;
+                if($msg->{type} eq "private") {
+                    $msghash{private} = 1;
+                    my @raw_recipients = @{$msg->{display_recipient}};
+                    my @display_recipients;
+                    if (scalar(@raw_recipients) > 1) {
+                        my $recip;
+                        for $recip (@raw_recipients) {
+                            unless ($recip->{email} eq $cfg{user}) {
+                                push @display_recipients, $recip->{email};
+                            }
+                        }
+                        $msghash{recipient} = join " ", @display_recipients;
+                    } else {
+                        $msghash{recipient} = $msg->{display_recipient}->[0]->{email};
+                    }
+                    $msghash{class} = "message";
+                    if($msg->{sender_email} eq $cfg{user}) {
+                        $msghash{direction} = 'out';
+                    }
+                }
+                my $bomsg = BarnOwl::Message->new(%msghash);
+                # queue_message returns the message round-tripped
+                # through owl_message. In particular, this means it
+                # has a meaningful id.
+                my $rtmsg = BarnOwl::queue_message($bomsg);
+                # note that only base messages, not edits, end up in
+                # here. Tim promises me that we will never see an
+                # update to an update, so we shouldn't need to
+                # retrieve updated messages via this
+                $msg_id_map{$rtmsg->zid} = $rtmsg->id;
+            } elsif($event->{type} eq "update_message") {
+                my $id = $event->{message_id};
+                if(!exists $msg_id_map{$id}) {
+                    BarnOwl::debug("Got update for unknown message $id, discarding");
+                } else {
+                    my $base_msg = BarnOwl::get_message_by_id($msg_id_map{$id});
+                    my %new_msghash = (
+                        type => 'Zulip',
+                        sender => $base_msg->sender,
+                        recipient => $base_msg->recipient,
+                        direction => $base_msg->direction,
+                        class => $base_msg->class,
+                        # instance needs to be potentially determined from new message
+                        unix_time => $event->{edit_timestamp},
+                        source => "zulip",
+                        location => "zulip",
+                        # content needs to be potentially determined from new message
+                        zid => $base_msg->id,
+                        sender_full_name => $base_msg->long_sender,
+                        opcode => "EDIT");
+                    if (exists $$event{'subject'}) {
+                        $new_msghash{'instance'} = $event->{subject};
+                    } else {
+                        $new_msghash{'instance'} = $base_msg->instance;
+                    }
+                    if (exists $$event{'content'}) {
+                        $new_msghash{'body'} = $event->{content};
+                    } else {
+                        $new_msghash{'body'} = $base_msg->body;
+                    }
+                    my $bomsg = BarnOwl::Message->new(%new_msghash);
+                    BarnOwl::queue_message($bomsg);
+                }
+                
+            } else {
+                BarnOwl::debug("Got unknown message");
+                BarnOwl::debug(encode_json($event));
+            }
+            $last_event_id = $event->{id};
+            do_poll();
+            return;
+        }
     }
     
 }
@@ -318,21 +318,21 @@ sub zulip {
     my $builder = URI->new("http://www.example.com");
     my %params = ("type" => $type, "to" => $recipient,  "content" => $msg);
     if ($subject ne "") {
-    	$params{"subject"} = $subject;
+        $params{"subject"} = $subject;
     }
     my $url = $cfg{'api_url'} . "/messages";
     my $req = POST($url, \%params); 
     http_post($url, $req->content, "headers" => {"Authorization" => authorization, "Content-Type" => "application/x-www-form-urlencoded"}, 
-	      session => $tls_ctx,
-	      sessionid => $tls_ctx,
-	      tls_ctx => $tls_ctx,sub { 
-		  my ($body, $headers) = @_;
-		  if($headers->{Status} < 400) {
-		      BarnOwl::message("Zulipgram sent");
-		  } else {
-		      BarnOwl::message("Error sending zulipgram: $headers->{Reason}!");
-		      BarnOwl::debug($body);
-		  }});
+              session => $tls_ctx,
+              sessionid => $tls_ctx,
+              tls_ctx => $tls_ctx,sub { 
+                  my ($body, $headers) = @_;
+                  if($headers->{Status} < 400) {
+                      BarnOwl::message("Zulipgram sent");
+                  } else {
+                      BarnOwl::message("Error sending zulipgram: $headers->{Reason}!");
+                      BarnOwl::debug($body);
+                  }});
     return;
 }
 
@@ -342,38 +342,38 @@ sub update_subs {
     my @add_param = ();
     my @remove_param = ();
     for my $add (@$add_list) {
-	push @add_param, {name => $add};
+        push @add_param, {name => $add};
     }
     my $url = $cfg{'api_url'} . "/users/me/subscriptions";
     my %params = ("add" => encode_json(\@add_param), "delete" => encode_json($remove_list));
     my $req = POST($url, \%params);
     http_request('PATCH' => $url,
-		 "body" => $req->content,
-		 "headers" => {"Authorization" => authorization, "Content-Type" => "application/x-www-form-urlencoded"},
-	      session => $tls_ctx,
-	      sessionid => $tls_ctx,
-	      tls_ctx => $tls_ctx,sub { 
-		  my ($body, $headers) = @_;
-		  if($headers->{Status} < 400) {
-		      &$cb();
-		  } else {
-		      BarnOwl::message("Error updating subscriptions: $headers->{Reason}!");
-		      BarnOwl::debug($body);
-		  }});
+                 "body" => $req->content,
+                 "headers" => {"Authorization" => authorization, "Content-Type" => "application/x-www-form-urlencoded"},
+              session => $tls_ctx,
+              sessionid => $tls_ctx,
+              tls_ctx => $tls_ctx,sub { 
+                  my ($body, $headers) = @_;
+                  if($headers->{Status} < 400) {
+                      &$cb();
+                  } else {
+                      BarnOwl::message("Error updating subscriptions: $headers->{Reason}!");
+                      BarnOwl::debug($body);
+                  }});
     return;
 }
 
 sub cmd_zulip_sub {
     my ($cmd, $stream) = @_;
     update_subs([$stream], [], sub {
-	BarnOwl::message("Subscribed to $stream");});
+        BarnOwl::message("Subscribed to $stream");});
     
 }
 
 sub cmd_zulip_unsub {
     my ($cmd, $stream) = @_;
     update_subs([], [$stream], sub {
-	BarnOwl::message("Unsubscribed from $stream");});
+        BarnOwl::message("Unsubscribed from $stream");});
     
 }
 
@@ -389,65 +389,65 @@ sub cmd_zulip_write {
     my $type;
     my $to;
     my $ret = GetOptionsFromArray(\@_,
-			       "c:s" => \$stream,
-			       "i:s" => \$subject);
+                               "c:s" => \$stream,
+                               "i:s" => \$subject);
     unless($ret) {
-	die("Usage: zulip:write [-c stream] [-i subject] [recipient] ...");
+        die("Usage: zulip:write [-c stream] [-i subject] [recipient] ...");
     }
     # anything left is a recipient
     if (scalar(@_) > 0) {
-	my @addresses = map {
-	    if(/@/) {
-		$_;
-	    } else {
-		$_ . "\@$cfg{'realm'}";
-	    }} @_;
-	$to = encode_json(\@addresses);
-	$type = "private";
-	    
+        my @addresses = map {
+            if(/@/) {
+                $_;
+            } else {
+                $_ . "\@$cfg{'realm'}";
+            }} @_;
+        $to = encode_json(\@addresses);
+        $type = "private";
+            
     } else {
-	$type = "stream";
-	$to = $stream
+        $type = "stream";
+        $to = $stream
     }
     BarnOwl::start_edit(prompt => $cmdline, type => 'edit_win', 
-			callback => sub {
-			    my ($text, $should_send) = @_;
-			    unless ($should_send) {
-				BarnOwl::message("zulip:write cancelled");
-				return;
-			    }
-			    zulip($type, $to, $subject, $text);
-			});
+                        callback => sub {
+                            my ($text, $should_send) = @_;
+                            unless ($should_send) {
+                                BarnOwl::message("zulip:write cancelled");
+                                return;
+                            }
+                            zulip($type, $to, $subject, $text);
+                        });
     
 }
 
 BarnOwl::new_command('zulip:login' => sub { cmd_zulip_login(@_); },
-		     {
-			 summary => "Log in to Zulip",
-			 usage => "zulip:login",
-			 description => "Start receiving Zulip messages"
-		     });
+                     {
+                         summary => "Log in to Zulip",
+                         usage => "zulip:login",
+                         description => "Start receiving Zulip messages"
+                     });
 
 BarnOwl::new_command('zulip:write' => sub { cmd_zulip_write(@_); },
-		     {
-			 summary => "Send a zulipgram",
-			 usage => "zulip:login [-c stream] [-i subject] [recipient(s)]",
-			 description => "Send a zulipgram to a stream, person, or set of people"
-		     });
+                     {
+                         summary => "Send a zulipgram",
+                         usage => "zulip:login [-c stream] [-i subject] [recipient(s)]",
+                         description => "Send a zulipgram to a stream, person, or set of people"
+                     });
 
 BarnOwl::new_command('zulip:subscribe' => sub { cmd_zulip_sub(@_); },
-		     {
-			 summary => "Subscribe to a Zulip stream",
-			 usage => "zulip:subscribe <stream name>",
-			 description => "Subscribe to a Zulip stream"
-		     });
+                     {
+                         summary => "Subscribe to a Zulip stream",
+                         usage => "zulip:subscribe <stream name>",
+                         description => "Subscribe to a Zulip stream"
+                     });
 
 BarnOwl::new_command('zulip:unsubscribe' => sub { cmd_zulip_unsub(@_); },
-		     {
-			 summary => "Unsubscribe from a Zulip stream",
-			 usage => "zulip:unsubscribe <stream name>",
-			 description => "Unsubscribe to a Zulip stream"
-		     });
+                     {
+                         summary => "Unsubscribe from a Zulip stream",
+                         usage => "zulip:unsubscribe <stream name>",
+                         description => "Unsubscribe to a Zulip stream"
+                     });
 
 
 sub default_realm {
@@ -457,3 +457,7 @@ sub default_realm {
 initialize();
 
 1;
+
+# Local Variables:
+# indent-tabs-mode: nil
+# End:

--- a/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
@@ -111,8 +111,10 @@ sub read_config {
             warn "SSL parameters specified, but no client credentials set.";
         }
     } else {
-        $cfg{'ssl_verify'} = 0;
-        warn "SSL parameters not specified. WILL NOT VERIFY SERVER CERTIFICATE";
+	$cfg{'ssl_verify'} = 0;
+	my $msg = "SSL parameters not specified. WILL NOT VERIFY SERVER CERTIFICATE. See README for details.";
+	BarnOwl::admin_message('Zulip Warning', "Zulip: $msg");
+	warn $msg;
     }
     
     $cfg{'user'} = $user;

--- a/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
@@ -151,7 +151,7 @@ sub register {
             } else {
                 $last_event_id = $response->{last_event_id};
                 $queue_id = $response->{queue_id};
-                $presence_timer = AnyEvent->timer(after => 1, interval => 10, cb => sub {
+                $presence_timer = AnyEvent->timer(after => 1, interval => 60, cb => sub {
                     my $presence_url = $cfg{'api_url'} . "/users/me/presence";
                     my %presence_params = (status => "active", new_user_input => "true");
                     my $presence_body = POST($presence_url, \%presence_params)->content;

--- a/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
+++ b/perl/modules/Zulip/lib/BarnOwl/Module/Zulip.pm
@@ -437,8 +437,8 @@ sub cmd_zulip_write {
     my $type;
     my $to;
     my $ret = GetOptionsFromArray(\@_,
-                               "c:s" => \$stream,
-                               "i:s" => \$subject);
+                               "c=s" => \$stream,
+                               "i=s" => \$subject);
     unless($ret) {
         die("Usage: zulip:write [-c stream] [-i subject] [recipient] ...");
     }

--- a/perlglue.xs
+++ b/perlglue.xs
@@ -59,7 +59,7 @@ getcurmsg()
 		RETVAL = owl_perlconfig_curmessage2hashref();
 	OUTPUT:
 		RETVAL
-
+	
 int
 getnumcols()
 	CODE:
@@ -155,6 +155,25 @@ queue_message(msg)
 	OUTPUT:
 		RETVAL
 
+SV *
+get_message_by_id(id)
+    int id
+    PREINIT:
+	   owl_message *m;
+           owl_messagelist *ml;
+    CODE:
+    {
+	    ml = owl_global_get_msglist(&g);
+	    m = owl_messagelist_get_by_id(ml, id);
+	    if(!m) {
+		    croak("No message with id %d!", id);
+	    }
+	    RETVAL = owl_perlconfig_message2hashref(m);
+    }
+OUTPUT:
+        RETVAL
+
+		
 void
 admin_message(header, body)
 	const char *header


### PR DESCRIPTION
This PR adds experimental support for the Zulip [https://zulipchat.com/] chat system. Zulip is inspired by Zephyr and so it fits pretty well into the model Barnowl expects.

As implemented, the code supports:

- sending and receiving zulip stream and personal messages (including
  with multiple recipients, mostly-functionally)

- listing, adding, and removing subscriptions

- minimal support for stream creation (if you try to sub to a stream
  that doesn't exist, it'll _probably_ create a new one with whatever
  your site's default settings are)

- full filter language support (message attributes are mostly the same
  as zephyr) including support for "punt" and mostly-functional
  smartfilter.

- support for displaying message edits (they show up as new messages
  with the correct stream/topic/sender with the new text and opcode
  EDIT)

It is missing, among other things:

- backfilling from history (this will be hard. barnowl currently only
  supports appending to the msglist from perl, and the msglist
  is also an array, so that's badness). Really, the right thing here is sqlite, but that's a very big piece to bite off.

- smartnarrow robustness (has been ported from C, but almost certainly
  still has weird corner cass)

- better handling of personals with multiple recipients 

- syncing the curmsg pointer with the server

- sending presence more cleverly (right now it just sends a ping every
  minute regardless of how active you are)

- deleting messages is probably interestingly broken right now w/r/t
  the hash of zid -> barnowl message id. make it work.

- being able to view user presence (ala zlocate/aim buddy list/jabber
  roster/etc)

- being able to invite people to invite-only streams (probably just a new command; should hopefully be straightforward)

- improved URL generation. We shouldn't have to warn people not to
  have a trailing / in their api_url setting (this one is probably an easy fix).

- editing messages

- option to allow in-place update of edited messages instead of adding
  a new message

- being able to create a stream with options (e.g. invite-only) set

- being able to edit attributes of streams (zephyr doesn't have 'em,
  but zulip does)

- being able to delete streams

- being able to see a list of people subscribed to a given stream

It is absolutely usable as a "daily driver" - I've been using it with the Zulip instance at my job for the past few years. The main driver for making this part of barnowl instead of an out-of-tree module is that support for handling message edit notifications required a small bit of XS (so you have to patch barnowl anyway to use it, so it may as well be in mainline)
