### PR TITLE
Define _DEFAULT_SOURCE in addition to _BSD_SOURCE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,8 +180,8 @@ AM_CONDITIONAL([ENABLE_ZCRYPT], [test "$HAVE_DES_STRING_TO_KEY" && dnl
                                  test "$HAVE_DES_ECB_ENCRYPT"])
 
 AM_CFLAGS="$AM_CFLAGS -D_XOPEN_SOURCE=600"
-dnl Define _BSD_SOURCE because zephyr needs caddr_t.
-AM_CFLAGS="$AM_CFLAGS -D_BSD_SOURCE"
+dnl Define _BSD_SOURCE/_DEFAULT_SOURCE because zephyr needs caddr_t.
+AM_CFLAGS="$AM_CFLAGS -D_BSD_SOURCE -D_DEFAULT_SOURCE"
 dnl Define __EXTENSIONS__ for strcasecmp on Solaris.
 AM_CFLAGS="$AM_CFLAGS -D__EXTENSIONS__"
 dnl Define _XOPEN_SOURCE_EXTENDED for some features in ncurses,


### PR DESCRIPTION
Fixes many copies of this warning with glibc 2.20.  (See _BSD_SOURCE in [feature_test_macros(7)](http://manpages.ubuntu.com/manpages/xenial/man7/feature_test_macros.7.html).)

```
In file included from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33:0,
                 from /usr/include/stdint.h:26,
                 from /usr/lib/gcc/x86_64-linux-gnu/7/include/stdint.h:9,
                 from /usr/include/ncursesw/curses.h:63,
                 from owl.h:20,
                 from message.c:1:
/usr/include/features.h:183:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^~~~~~~
```
