### PR TITLE
Rip out Kerberos IV support, migrate to “new” OpenSSL DES API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,35 +53,15 @@ AC_ARG_WITH([zephyr],
   [],
   [with_zephyr=check])
 
-AC_ARG_WITH([krb4],
-  AS_HELP_STRING([--with-krb4],
-                 [Build with kerberos IV]))
-
 AS_IF([test "x$with_zephyr" != xno],
-  [have_krb4=no
-
-   AS_IF([test "x$with_krb4" != "xno"],
-   [AC_MSG_CHECKING([for Kerberos IV])
-    AS_IF([krb5-config krb4 --libs >/dev/null 2>&1],
-      [AC_MSG_RESULT([yes])
-       have_krb4=yes
-       AC_DEFINE([HAVE_KERBEROS_IV], [1], [Define if you have kerberos IV])
-       AM_CFLAGS="${AM_CFLAGS} `krb5-config krb4 --cflags`"
-       LIBS="${LIBS} `krb5-config krb4 --libs`"
-      ],
-      [AC_MSG_RESULT([no])
-       AS_IF([test "x$with_krb4" = "xyes"],
-             [AC_MSG_ERROR([Kerberos IV requested but not found])])])])
-
-   AS_IF([test "x$have_krb4" != xyes],
-     [PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto],
-        [AM_CFLAGS="${AM_CFLAGS} ${LIBCRYPTO_CFLAGS}"
-         LIBS="${LIBS} ${LIBCRYPTO_LIBS}"
-        ],
-        [PKG_CHECK_MODULES([OPENSSL], [openssl],
-           [AM_CFLAGS="${AM_CFLAGS} ${OPENSSL_CFLAGS}"
-            LIBS="${LIBS} ${OPENSSL_LIBS}"
-           ])])])
+  [PKG_CHECK_MODULES([LIBCRYPTO], [libcrypto],
+     [AM_CFLAGS="${AM_CFLAGS} ${LIBCRYPTO_CFLAGS}"
+      LIBS="${LIBS} ${LIBCRYPTO_LIBS}"
+     ],
+     [PKG_CHECK_MODULES([OPENSSL], [openssl],
+        [AM_CFLAGS="${AM_CFLAGS} ${OPENSSL_CFLAGS}"
+         LIBS="${LIBS} ${OPENSSL_LIBS}"
+        ])])
 
    AC_CHECK_LIB([zephyr], [ZGetSender],
    [LIBS="$LIBS -lzephyr"

--- a/configure.ac
+++ b/configure.ac
@@ -81,9 +81,9 @@ AS_IF([test "x$with_zephyr" != xno],
 
 AC_CHECK_FUNCS([use_default_colors])
 AC_CHECK_FUNCS([resizeterm], [], [AC_MSG_ERROR([No resizeterm found])])
-AC_CHECK_FUNCS([des_string_to_key DES_string_to_key], [HAVE_DES_STRING_TO_KEY=1])
-AC_CHECK_FUNCS([des_ecb_encrypt DES_ecb_encrypt], [HAVE_DES_ECB_ENCRYPT=1])
-AC_CHECK_FUNCS([des_key_sched DES_key_sched], [HAVE_DES_KEY_SCHED=1])
+AC_CHECK_FUNCS([DES_string_to_key], [HAVE_DES_STRING_TO_KEY=1])
+AC_CHECK_FUNCS([DES_ecb_encrypt], [HAVE_DES_ECB_ENCRYPT=1])
+AC_CHECK_FUNCS([DES_key_sched], [HAVE_DES_KEY_SCHED=1])
 
 dnl Checks for header files.
 AC_HEADER_STDC

--- a/zcrypt.c
+++ b/zcrypt.c
@@ -94,11 +94,11 @@ cipher_pair ciphers[NCIPHER] = {
   [CIPHER_AES] = { do_encrypt_aes, do_decrypt_aes},
 };
 
-static void owl_zcrypt_string_to_schedule(char *keystring, des_key_schedule *schedule) {
-  des_cblock key;
+static void owl_zcrypt_string_to_schedule(char *keystring, DES_key_schedule *schedule) {
+  DES_cblock key;
 
-  des_string_to_key(keystring, &key);
-  des_key_sched(&key, *schedule);
+  DES_string_to_key(keystring, &key);
+  DES_key_sched(&key, schedule);
 }
 
 void usage(FILE *file, const char *progname)
@@ -719,7 +719,7 @@ int do_encrypt(int zephyr, const char *class, const char *instance,
 
 int do_encrypt_des(const char *keyfile, const char *in, int length, FILE *outfile)
 {
-  des_key_schedule schedule;
+  DES_key_schedule schedule;
   unsigned char input[8], output[8];
   const char *inptr;
   int num_blocks, last_block_size;
@@ -765,7 +765,7 @@ int do_encrypt_des(const char *keyfile, const char *in, int length, FILE *outfil
       memset(input + size, 0, 8 - size);
 
     /* Encrypt and output the block */
-    des_ecb_encrypt(&input, &output, schedule, TRUE);
+    DES_ecb_encrypt(&input, &output, &schedule, TRUE);
     block_to_ascii(output, outfile);
 
     if (size < 8)
@@ -904,7 +904,7 @@ int do_decrypt_aes(const char *keyfile) {
 }
 
 int do_decrypt_des(const char *keyfile) {
-  des_key_schedule schedule;
+  DES_key_schedule schedule;
   unsigned char input[8], output[8];
   char tmp[9];
   char *keystring;
@@ -914,7 +914,7 @@ int do_decrypt_des(const char *keyfile) {
     'tmp', which has the final byte zeroed, to ensure that we always
     have a NULL-terminated string we can call printf/strlen on.
 
-    We don't pass 'tmp' to des_ecb_encrypt directly, because it's
+    We don't pass 'tmp' to DES_ecb_encrypt directly, because it's
     prototyped as taking 'unsigned char[8]', and this avoids a stupid
     cast.
 
@@ -932,7 +932,7 @@ int do_decrypt_des(const char *keyfile) {
 
   while (read_ascii_block(input))
   {
-    des_ecb_encrypt(&input, &output, schedule, FALSE);
+    DES_ecb_encrypt(&input, &output, &schedule, FALSE);
     memcpy(tmp, output, 8);
     printf("%s", tmp);
   }

--- a/zcrypt.c
+++ b/zcrypt.c
@@ -20,11 +20,7 @@
 
 #include <config.h>
 
-#ifdef HAVE_KERBEROS_IV
-#include <kerberosIV/des.h>
-#else
 #include <openssl/des.h>
-#endif
 
 #include "filterproc.h"
 
@@ -99,14 +95,10 @@ cipher_pair ciphers[NCIPHER] = {
 };
 
 static void owl_zcrypt_string_to_schedule(char *keystring, des_key_schedule *schedule) {
-#ifdef HAVE_KERBEROS_IV
   des_cblock key;
-#else
-  des_cblock _key, *key = &_key;
-#endif
 
-  des_string_to_key(keystring, key);
-  des_key_sched(key, *schedule);
+  des_string_to_key(keystring, &key);
+  des_key_sched(&key, *schedule);
 }
 
 void usage(FILE *file, const char *progname)


### PR DESCRIPTION
The new API was added in OpenSSL 0.9.7.  The old API was removed in OpenSSL 1.1.0.