### PR TITLE
Properly check for dlsym() errors

### DIFF
--- a/closures.c
+++ b/closures.c
@@ -20,8 +20,14 @@ const char *owl_closure_init(void)
     sv_from_gvalue = dlsym(handle, "gperl_sv_from_value");
     perl_closure_new = dlsym(handle, "gperl_closure_new");
     /* ... */
-    res = dlerror();
-    dlclose(handle);
+    if (dlclose(handle) != 0
+        || gvalue_from_sv == NULL
+        || sv_from_gvalue == NULL
+        || perl_closure_new == NULL) {
+            res = dlerror();
+    } else {
+      res = NULL;
+    }
   }
   return res;
 }


### PR DESCRIPTION
In closures.c we dlopen() the main process address space so we can get references to gvalue_from_sv, sv_from_gvalue, and perl_closure_new, but we only check for errors by seeing if dlerror() returns a non-NULL pointer (string).  This is not correct, since we are only supposed to inspect dlerror()'s contents if one of a certain list of functions has returned an error (dlerror() returns information about the latest such error).

This causes problems on FreeBSD, where the NSS implementation in libc performs a dlsym() lookup of a "_nss_cache_cycle_protection_function" symbls, which fails in all processes other than nscd.  The FreeBSD libc does not subsequently call dlerror() to clear the error string and so it remains cached until we inspect it, and we erroneously treat this cached value as indicating an error in our dlsym() usage, which trickles up and becomes a fatal error at startup.

Fix the issue by only calling dlerror() if we experienced an error return from dlsym() or dlclose(), clearing res to NULL in the success case.